### PR TITLE
Added Fusion360 Courses WS20/21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode/

--- a/docs/CAD/Fusion360.md
+++ b/docs/CAD/Fusion360.md
@@ -1,0 +1,13 @@
+
+# Fusion 360 
+
+Fusion 360 is a 3D CAD-Program made by Autodesk. 
+It is cloud based, runs on Mac and Windows and while it has less features than more established CAD-Packages it is easy to learn for beginners. 
+At BURG we have been teaching Fusion 360 for the last few Semesters. 
+
+Here you can find all the materials for the beginner and advanced course during the winter-semester 2020/2021. 
+The course was held in German. 
+
+### [CAD-1 Fusion360 for Beginners ](CAD/fusion360course/CAD1-beginner.md)
+
+### [CAD-2 Fusion360 Advanced ](CAD/fusion360course/CAD2-advanced.md)

--- a/docs/CAD/Fusion360.md
+++ b/docs/CAD/Fusion360.md
@@ -11,6 +11,6 @@ It is cloud based, runs on Mac and Windows and while it has less features than m
 Here you can find all the materials for the beginner and advanced courses that were held during the winter-semester 2020/2021.  
 The courses were **held in German**, and feature video tutorials as well as summaries and links to further learning materials.  
 
-[CAD-1 Fusion360 for Beginners](fusion360course/CAD1-beginner.md) (in German)  
+[CAD-1 Fusion360 for Beginners](CAD/fusion360course/CAD1-beginner.md) (in German)  
 
-[CAD-2 Fusion360 Advanced](fusion360course/CAD2-advanced.md) (in German)  
+[CAD-2 Fusion360 Advanced](CAD/fusion360course/CAD2-advanced.md) (in German)  

--- a/docs/CAD/Fusion360.md
+++ b/docs/CAD/Fusion360.md
@@ -8,6 +8,6 @@ At BURG we have been teaching Fusion 360 for the last few Semesters.
 Here you can find all the materials for the beginner and advanced course during the winter-semester 2020/2021.  
 The course was held in German.  
 
-### [CAD-1 Fusion360 for Beginners ](CAD/fusion360course/CAD1-beginner.md)  
+### [CAD-1 Fusion360 for Beginners](CAD/fusion360course/CAD1-beginner.md)  
 
-### [CAD-2 Fusion360 Advanced ](CAD/fusion360course/CAD2-advanced.md)  
+### [CAD-2 Fusion360 Advanced](CAD/fusion360course/CAD2-advanced.md)  

--- a/docs/CAD/Fusion360.md
+++ b/docs/CAD/Fusion360.md
@@ -1,13 +1,13 @@
 
-# Fusion 360 
+# Fusion 360
 
-Fusion 360 is a 3D CAD-Program made by Autodesk. 
-It is cloud based, runs on Mac and Windows and while it has less features than more established CAD-Packages it is easy to learn for beginners. 
-At BURG we have been teaching Fusion 360 for the last few Semesters. 
+Fusion 360 is a 3D CAD-Program made by Autodesk.  
+It is cloud based, runs on Mac and Windows and while it has less features than more established CAD-Packages it is easy to learn for beginners.  
+At BURG we have been teaching Fusion 360 for the last few Semesters.  
 
-Here you can find all the materials for the beginner and advanced course during the winter-semester 2020/2021. 
-The course was held in German. 
+Here you can find all the materials for the beginner and advanced course during the winter-semester 2020/2021.  
+The course was held in German.  
 
-### [CAD-1 Fusion360 for Beginners ](CAD/fusion360course/CAD1-beginner.md)
+### [CAD-1 Fusion360 for Beginners ](CAD/fusion360course/CAD1-beginner.md)  
 
-### [CAD-2 Fusion360 Advanced ](CAD/fusion360course/CAD2-advanced.md)
+### [CAD-2 Fusion360 Advanced ](CAD/fusion360course/CAD2-advanced.md)  

--- a/docs/CAD/Fusion360.md
+++ b/docs/CAD/Fusion360.md
@@ -8,6 +8,10 @@ At BURG we have been teaching Fusion 360 for the last few Semesters.
 Here you can find all the materials for the beginner and advanced course during the winter-semester 2020/2021.  
 The course was held in German.  
 
-### [CAD-1 Fusion360 for Beginners](CAD/fusion360course/CAD1-beginner.md)  
+-----
 
-### [CAD-2 Fusion360 Advanced](CAD/fusion360course/CAD2-advanced.md)  
+## Fusion Courses WS 2020/2021
+
+### [CAD-1 Fusion360 for Beginners](fusion360course/CAD1-beginner.md)  
+
+### [CAD-2 Fusion360 Advanced](fusion360course/CAD2-advanced.md)  

--- a/docs/CAD/Fusion360.md
+++ b/docs/CAD/Fusion360.md
@@ -1,7 +1,7 @@
 
 # Fusion 360
 
-[ Fusion 360 ](https://www.autodesk.de/products/fusion-360/overview) is a 3D CAD-Program made by Autodesk.  
+[Fusion 360](https://www.autodesk.de/products/fusion-360/overview) is a 3D CAD-Program made by Autodesk.  
 It is cloud based, runs on Mac and Windows and while it has less features than more established CAD-Packages (like SOlidworks or Inventor) it is easy to learn for beginners and much more affordable for students and professionals than many other CAD-Programs. These factors are the reason Fusion360 has been integrated into the Industrial-Design curriculum at BURG alongside Solidworks and Rhinoceros3D and they make it a good choice for anyone looking to improve their 3D-modelling skills.  
 
 -----

--- a/docs/CAD/Fusion360.md
+++ b/docs/CAD/Fusion360.md
@@ -1,17 +1,16 @@
 
 # Fusion 360
 
-Fusion 360 is a 3D CAD-Program made by Autodesk.  
-It is cloud based, runs on Mac and Windows and while it has less features than more established CAD-Packages it is easy to learn for beginners.  
-At BURG we have been teaching Fusion 360 for the last few Semesters.  
-
-Here you can find all the materials for the beginner and advanced course during the winter-semester 2020/2021.  
-The course was held in German.  
+[ Fusion 360 ](https://www.autodesk.de/products/fusion-360/overview) is a 3D CAD-Program made by Autodesk.  
+It is cloud based, runs on Mac and Windows and while it has less features than more established CAD-Packages (like SOlidworks or Inventor) it is easy to learn for beginners and much more affordable for students and professionals than many other CAD-Programs. These factors are the reason Fusion360 has been integrated into the Industrial-Design curriculum at BURG alongside Solidworks and Rhinoceros3D and they make it a good choice for anyone looking to improve their 3D-modelling skills.  
 
 -----
 
 ## Fusion Courses WS 2020/2021
 
-### [CAD-1 Fusion360 for Beginners](fusion360course/CAD1-beginner.md)  
+Here you can find all the materials for the beginner and advanced courses that were held during the winter-semester 2020/2021.  
+The courses were **held in German**, and feature video tutorials as well as summaries and links to further learning materials.  
 
-### [CAD-2 Fusion360 Advanced](fusion360course/CAD2-advanced.md)  
+[CAD-1 Fusion360 for Beginners](fusion360course/CAD1-beginner.md) (in German)  
+
+[CAD-2 Fusion360 Advanced](fusion360course/CAD2-advanced.md) (in German)  

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -162,64 +162,15 @@ https://www.youtube.com/watch?v=ZPyqPNb5BSI&
 
 **Lernziele/ Topics:**
 
-Einführung: Inspect-Funktionen
+- Einführung: Inspect-Funktionen
 
-Externe 3D- und 2D- Modelle in Fusion Laden ([Handbuch](https://www.autodesk.com/products/fusion-360/blog/data-exchange-in-fusion-360-part-1/))
+- Externe 3D- und 2D- Modelle in Fusion Laden ([Handbuch](https://www.autodesk.com/products/fusion-360/blog/data-exchange-in-fusion-360-part-1/))
 
-Schraubenkatalog nutzen
+- Schraubenkatalog nutzen
 
-Objekte Rendern
+- Objekte Rendern
 
-### Übersicht 3D-Dateiformate
-
-**Proprietäre Formate** **(Softwaregebunden)**
-
-- [Rhino](https://www.rhino3d.com/) Files (*.3dm).
-- [Autodesk Inventor](https://www.autodesk.com/products/inventor/overview) Files (*.ipt,*.iam - up to Inventor 2019)
-- [SolidWorks](https://www.solidworks.com/) Files (*.prt,*.asm, *.sldprt,*.sldasm , **.slddrw)*
-- [Autodesk Alias](https://www.autodesk.com/products/alias-products/overview?plc=ALSCPT&term=1-YEAR&support=ADVANCED&quantity=1) (*.wire)
-- [123D](https://www.autodesk.com/solutions/123d-apps) File (*.123dx)
-- [AutoCAD](https://www.autodesk.com/products/autocad/overview?support=ADVANCED) DWG Files (*.dwg)
-- [SketchUp](https://www.sketchup.com/products/sketchup-pro) Files (*.skp)
-- [CATIA](https://www.3ds.com/de/produkte-und-services/catia/)V5 Files (*.CATProduct,*.CATPart)
-- Autodesk Fusion 360 Archive Files (*.f3d)
-- [Siemens NX](https://www.plm.automation.siemens.com/global/en/products/nx/) (*prt)
-- [Parasolid](https://de.wikipedia.org/wiki/Parasolid) Files (*.x_b,*.x_t)
-- [Pro/ENGINEER and Creo Parametric](https://www.ptc.com/en/products/creo/whats-new) Files (*.asm,*.prt)
-- [Pro/ENGINEER Granite](https://www.ptc.com/de/~/media/DE/Files/PDFs/CAD/GRANITE_Interoperability_Kernel.ashx?la=en) Files (*.g)
-- [Pro/ENGINEER Neutral](http://support.ptc.com/help/creo/creo_pma/usascii/index.html#page/data_exchange/interface/About_Part_and_Assembly_Neutral_Files.html) Files(*.neu)
-- Autodesk Fusion 360 Toolpath Archive Files (*.cam360)
-- [Blender](https://www.blender.org/) File (.blend)
-
-[Super Nützlicher CAD Conversion Finder](https://www.cadforum.cz/cadforum_en/formats.asp)
-
-[Noch Mehr CAD und 3D-Programme](https://en.wikipedia.org/wiki/Comparison_of_computer-aided_design_software)
-
-**Interchange Formate (unabhängig von Software):**
-
-| Format                                     | Ending                      | Type                | Additional Data                                                                                                                                                                                                                                                           | Notes                                 |
-| ------------------------------------------ | --------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| STEP                                       | .stp / .step                | BREP<br>Surfaces    | Different additional  data according to Standards                                                                                                                                                                                                                         | Most standard file format             |
-| IGES                                       | .igs / .iges                | BREP<br>Surfaces    | circuit diagrams, wireframe, freeform surface or solid modeling representations                                                                                                                                                                                           | Not updated since 1994                |
-| Wavefront OBJ                              | .obj                        | Both Mesh and Nurbs | Texture                                                                                                                                                                                                                                                                   |                                       |
-| AMF                                        | .amf                        | Mesh                | color, materials, lattices, and constellations                                                                                                                                                                                                                            |                                       |
-| Collada                                    | .dae                        | Mesh                | Colors, Textures, Collaborative, Physics, Animations                                                                                                                                                                                                                      |                                       |
-| 3MF                                        | .3mf                        | Mesh                | Full color and texture support in a single file<br>Support structures attached to part data<br>Full tray support for direct machine preparation<br>Efficient storage of beam lattices<br>Multiple material support<br>Native integration in Microsoft Office and Paint 3D | Designed for industrial manufacturing |
-| STL - Stereolithography                    | .stl                        | Mesh                | No additional information                                                                                                                                                                                                                                                 |                                       |
-| Polygon File Format (Pointcloud)           | .ply                        | Mesh                | color and transparency, surface normals, texture coordinates and data confidence values                                                                                                                                                                                   |                                       |
-| VRML-<br>Virtual Reality Modeling Language | .wrl<br>.wrz                | Mesh                |                                                                                                                                                                                                                                                                           |                                       |
-| X3D                                        | .x3d<br>.x3dv, .x3db, .x3dz |                     | Geospatial<br>Animation<br>NURBS                                                                                                                                                                                                                                          |                                       |
-| ACIS - SAT/SMT                             | .sat                        | BREP<br>Surfaces    | integrates wireframe model, surface, and solid modeling functionality with both manifold and non-manifold topology, and a rich set of geometric operations.                                                                                                               |                                       |
-| DXF<br>(Drawing Exchange Format)           | .dxf                        | 2D Paths            |                                                                                                                                                                                                                                                                           |                                       |
-|                                            |                             |                     |                                                                                                                                                                                                                                                                           |                                       |
-
-Alle Dateiformate die Fusion einlesen und umwandeln kann:
-<https://knowledge.autodesk.com/support/fusion-360/troubleshooting/caas/sfdcarticles/sfdcarticles/File-formats-supported-by-Fusion-360.html>
-
-Leitfaden Dateiexport:
-Immer die Ursprungsdatei mit exportieren um keine Informationen zu verlieren.
-Nach Möglichkeit und Verwendungszweck verschiedene Interchange Formate mitliefern.
-Nützliches Tool um zu sehen welche Programme welche Formate öffnen können: Cadforum.cz
+[3DFormat-Table](./Tabelle_3DFormate.md ':include')
 
 ### Tutorial  und Dateien
 
@@ -245,7 +196,7 @@ Webseiten zum Download von 3D-Modellen:
 - <https://gallery.autodesk.com/>
 - <https://b2b.partcommunity.com/community/>
 - <https://www.traceparts.com/en>
-- <https://www.3dcontentcentral.com/>
+- <https://www.3dcontentcentral.com/> <!-- markdown-link-check-disable-line -->
 - <https://www.turbosquid.com/Search/3D-Models/free/cad>
 
  Homework bis 18.12.:

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -13,25 +13,26 @@
     - [Tutorial  und Dateien:](#tutorial--und-dateien)
   - [Session 07: Sheet Metal](#session-07-sheet-metal)
   - [Session 08: Flächen](#session-08-flächen)
+
 ----------
 
 ## Vorbereitung
 
-- Fusion Installieren 
-    - [ Autodesk Education Account ](https://accounts.autodesk.com/register)
-    - [ Fusion 360 Download ](https://www.autodesk.com/education/edu-software/overview?sorting=featured&page=1&filters=pdm-products,individual#card-f360b)
+- Fusion Installieren
+  - [Autodesk Education Account](https://accounts.autodesk.com/register)
+  - [Fusion 360 Download](https://www.autodesk.com/education/edu-software/overview?sorting=featured&page=1&filters=pdm-products,individual#card-f360b)
 
 ----------
 
 ## Session 1: Einstieg
 
-Lernziel: Überblick über die Fusion-Nutzungsoberfläche. Erste Geometrien Erstellen durch Skizzieren. 
+Lernziel: Überblick über die Fusion-Nutzungsoberfläche. Erste Geometrien Erstellen durch Skizzieren.
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/UYnO-d12DbQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-https://youtube.com/UYnO-d12DbQ
+<https://youtube.com/UYnO-d12DbQ>
 
-**Topics**: 
+**Topics**:
 
 **Nutzungsoberfläche**
 
@@ -44,7 +45,7 @@ https://youtube.com/UYnO-d12DbQ
     - Bemaßung
     - Constraints
 
-**Extrudieren** 
+**Extrudieren**
 
     - Join
     - Cut
@@ -52,10 +53,10 @@ https://youtube.com/UYnO-d12DbQ
 
 ## Session 02: Deep Dive “Create”
 
-Lernziel: Verschiedene Methoden zum Geometrien erstellen  kennenlernen, weitere Skizzierungsmethoden nutzen 
+Lernziel: Verschiedene Methoden zum Geometrien erstellen  kennenlernen, weitere Skizzierungsmethoden nutzen
 
 Topics:
-**Skizzieren** 
+**Skizzieren**
 
     - Konstruktionsebenen + Achsen 
     - Projektionen 
@@ -69,7 +70,7 @@ Topics:
     - Intro `Create Menu` unter `Surface` 
     - Pattern 
 
-**Meta** 
+**Meta**
 
     - Face vs Body vs Component vs Feature
 
@@ -77,21 +78,20 @@ Keine Angst: mein Gesicht wird im Lauf des Tutorials reduiziert, das müsst ihr 
 
 <iframe width="600" height="400" src="https://youtube.com/embed/oqnaJMujp7M" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-
 Hausaufgabe
     Tutorial dieser Woche Durcharbeiten
-    Karaffe nach Vorgabe modellieren mithilfe dieses Tutorials: 
-https://www.youtube.com/watch?v=auZZ_GV4q6s&
+    Karaffe nach Vorgabe modellieren mithilfe dieses Tutorials:
+<https://www.youtube.com/watch?v=auZZ_GV4q6s>&
 
 <iframe width="600" height="400" src="https://youtube.com/embed/auZZ_GV4q6s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>u
 
 ----------
 
-## Session3: Patterns!
+## Session3: Patterns
 
-Lernziele: Pattern Funktion Kennenlernen in der Skizze und für Bodies, Features und Components 
+Lernziele: Pattern Funktion Kennenlernen in der Skizze und für Bodies, Features und Components
 
-Einleitung: 
+Einleitung:
 
     Reihenfolge im CAD
     Welche Funktion nutze ich wann? 
@@ -100,46 +100,42 @@ Einleitung:
 
 **Wann nutze ich welche Pattern-Funktion?**
 
-Skizze: 
+Skizze:
 
     - Wenn keine weiteren Anpassungen nötig sind
     - Wenn die Skizze auf eine Oberfläche projeziert werden soll 
     - Zum Export als DXF 
 
-Bodies: 
+Bodies:
 
     - um die angereihten Körper zu bearbeiten bevor sie mit cut oder join mit einem anderen Körper verbunden werden
     - Um im Anschluss einzigartige Komponenten ab zu leiten 
 
-Feature: 
+Feature:
 
     - Um einen oder mehrere Schritte aus der Timeline zu pattern
     - Kann für jegliche Aktionen genutzt werden 
 
-Component: 
+Component:
 
     - Um das gleiche Bauteil mehrmals an zu Ordnen
 
-**Tutorial:** 
+**Tutorial:**
 
-https://www.youtube.com/watch?v=rpOxkW5eY4s&
-
+<https://www.youtube.com/watch?v=rpOxkW5eY4s>&
 
 <iframe width="600" height="400" src="https://youtube.com/embed/rpOxkW5eY4s
 " frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 
 ----------
 
 ## Session 04: Create Form (Sculpting Mode)
 
-
 <iframe width="600" height="400" src="https://youtube.com/embed/bATAm1ZuLjk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-
 <a data-pin-do="embedBoard" data-pin-board-width="700" data-pin-scale-height="400" data-pin-scale-width="60" href="https://www.pinterest.de/rowlllllll/organic-modelling/"></a>
-https://www.pinterest.de/rowlllllll/organic-modelling/
-Homework: 
+<https://www.pinterest.de/rowlllllll/organic-modelling/>
+Homework:
 
 Modelliert ein Objekt nach Vorlage mit der “Create Form” - Funktion
 
@@ -147,59 +143,54 @@ Modelliert ein Objekt nach Vorlage mit der “Create Form” - Funktion
 
 ## Session 05: Baugruppen
 
-Lernziele: 
+Lernziele:
 **Modellieren mit Baugruppen**
 
     Objekte miteinander verbinden
     Externe Objekte in das Modell laden
     Parameter verwenden
 
-
-
 <iframe width="600" height="400" src="https://www.youtube.com/embed/ZPyqPNb5BSI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 https://www.youtube.com/watch?v=ZPyqPNb5BSI&
 
-
-https://youtube.com/ZPyqPNb5BSI
-
-
+<https://youtube.com/ZPyqPNb5BSI>
 
 ----------
 
-## Session 06: Externe Dateien und Rendern 
+## Session 06: Externe Dateien und Rendern
 
-**Lernziele/ Topics:** 
+**Lernziele/ Topics:**
 
 Einführung: Inspect-Funktionen
 
 Externe 3D- und 2D- Modelle in Fusion Laden ([Handbuch](https://www.autodesk.com/products/fusion-360/blog/data-exchange-in-fusion-360-part-1/))
 
-Schraubenkatalog nutzen 
+Schraubenkatalog nutzen
 
-Objekte Rendern 
+Objekte Rendern
 
 ### Übersicht 3D-Dateiformate
 
 **Proprietäre Formate** **(Softwaregebunden)**
 
 - [Rhino](https://www.rhino3d.com/) Files (*.3dm).
-- [Autodesk Inventor](https://www.autodesk.com/products/inventor/overview) Files (*.ipt, *.iam - up to Inventor 2019)
-- [SolidWorks](https://www.solidworks.com/) Files (*.prt, *.asm, *.sldprt, *.sldasm , **.slddrw)*
+- [Autodesk Inventor](https://www.autodesk.com/products/inventor/overview) Files (*.ipt,*.iam - up to Inventor 2019)
+- [SolidWorks](https://www.solidworks.com/) Files (*.prt,*.asm, *.sldprt,*.sldasm , **.slddrw)*
 - [Autodesk Alias](https://www.autodesk.com/products/alias-products/overview?plc=ALSCPT&term=1-YEAR&support=ADVANCED&quantity=1) (*.wire)
 - [123D](https://www.autodesk.com/solutions/123d-apps) File (*.123dx)
 - [AutoCAD](https://www.autodesk.com/products/autocad/overview?support=ADVANCED) DWG Files (*.dwg)
 - [SketchUp](https://www.sketchup.com/products/sketchup-pro) Files (*.skp)
-- [CATIA ](https://www.3ds.com/de/produkte-und-services/catia/)V5 Files (*.CATProduct, *.CATPart)
+- [CATIA](https://www.3ds.com/de/produkte-und-services/catia/)V5 Files (*.CATProduct,*.CATPart)
 - Autodesk Fusion 360 Archive Files (*.f3d)
 - [Siemens NX](https://www.plm.automation.siemens.com/global/en/products/nx/) (*prt)
-- [Parasolid](https://de.wikipedia.org/wiki/Parasolid) Files (*.x_b, *.x_t)
-- [Pro/ENGINEER and Creo Parametric](https://www.ptc.com/en/products/creo/whats-new) Files (*.asm, *.prt)
+- [Parasolid](https://de.wikipedia.org/wiki/Parasolid) Files (*.x_b,*.x_t)
+- [Pro/ENGINEER and Creo Parametric](https://www.ptc.com/en/products/creo/whats-new) Files (*.asm,*.prt)
 - [Pro/ENGINEER Granite](https://www.ptc.com/de/~/media/DE/Files/PDFs/CAD/GRANITE_Interoperability_Kernel.ashx?la=en) Files (*.g)
 - [Pro/ENGINEER Neutral](http://support.ptc.com/help/creo/creo_pma/usascii/index.html#page/data_exchange/interface/About_Part_and_Assembly_Neutral_Files.html) Files(*.neu)
 - Autodesk Fusion 360 Toolpath Archive Files (*.cam360)
 - [Blender](https://www.blender.org/) File (.blend)
 
-[Super Nützlicher CAD Conversion Finder ](https://www.cadforum.cz/cadforum_en/formats.asp)
+[Super Nützlicher CAD Conversion Finder](https://www.cadforum.cz/cadforum_en/formats.asp)
 
 [Noch Mehr CAD und 3D-Programme](https://en.wikipedia.org/wiki/Comparison_of_computer-aided_design_software)
 
@@ -222,26 +213,22 @@ Objekte Rendern
 |                                            |                             |                     |                                                                                                                                                                                                                                                                           |                                       |
 
 Alle Dateiformate die Fusion einlesen und umwandeln kann:
-https://knowledge.autodesk.com/support/fusion-360/troubleshooting/caas/sfdcarticles/sfdcarticles/File-formats-supported-by-Fusion-360.html
+<https://knowledge.autodesk.com/support/fusion-360/troubleshooting/caas/sfdcarticles/sfdcarticles/File-formats-supported-by-Fusion-360.html>
 
-Leitfaden Dateiexport: 
-Immer die Ursprungsdatei mit exportieren um keine Informationen zu verlieren. 
+Leitfaden Dateiexport:
+Immer die Ursprungsdatei mit exportieren um keine Informationen zu verlieren.
 Nach Möglichkeit und Verwendungszweck verschiedene Interchange Formate mitliefern.
 Nützliches Tool um zu sehen welche Programme welche Formate öffnen können: Cadforum.cz
 
-
-### Tutorial  und Dateien: 
+### Tutorial  und Dateien
 
 Solidworks Dateien Download
-https://www.dropbox.com/sh/usd62jexewc6ggp/AACkJ-t9Tnk_LFQl1eQxe7Uda?dl=0
-
-
-
+<https://www.dropbox.com/sh/usd62jexewc6ggp/AACkJ-t9Tnk_LFQl1eQxe7Uda?dl=0>
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=6O-ftuqFnmI&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-https://youtube.com/6O-ftuqFnmI
- 
+<https://youtube.com/6O-ftuqFnmI>
+
  Links:
  Kostenlose HDRIs:
 
@@ -253,39 +240,37 @@ https://youtube.com/6O-ftuqFnmI
 
 Webseiten zum Download von 3D-Modellen:
 
-- https://grabcad.com/
-- https://gallery.autodesk.com/
-- https://b2b.partcommunity.com/community/
-- https://www.traceparts.com/en
-- https://www.3dcontentcentral.com/
-- https://www.turbosquid.com/Search/3D-Models/free/cad
+- <https://grabcad.com/>
+- <https://gallery.autodesk.com/>
+- <https://b2b.partcommunity.com/community/>
+- <https://www.traceparts.com/en>
+- <https://www.3dcontentcentral.com/>
+- <https://www.turbosquid.com/Search/3D-Models/free/cad>
 
- 
+ Homework bis 18.12.:
 
- Homework bis 18.12.: 
 - Ladet euch ein oder mehrere HDRIs runter
 - Sucht nach interessanten / passenden / witzigen 3D-modellen im Internet oder modelliert selbst welche.
-- Importiert die Modelle in Fusion (In einen Unterordner in eurem Persönlichen Ordner!) und bearbeitet sie falls nötig. 
-- Erstellt interessante (Chaos-) Renderings mit den HDRIs, Modellen und interessanten Materialkombinationen. 
-- Nutzt euer gestalterisches Gespür um eine cooles Bild zu erzeugen 
+- Importiert die Modelle in Fusion (In einen Unterordner in eurem Persönlichen Ordner!) und bearbeitet sie falls nötig.
+- Erstellt interessante (Chaos-) Renderings mit den HDRIs, Modellen und interessanten Materialkombinationen.
+- Nutzt euer gestalterisches Gespür um eine cooles Bild zu erzeugen
 
 Nochmal eine Kurzinfo zur Hausaufgabe inklusive kleinem Beispiel
 
-
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=JrCm6O7inho&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-https://youtube.com/JrCm6O7inho
+<https://youtube.com/JrCm6O7inho>
 
 ----------
 
-## Session 07: Sheet Metal 
-
+## Session 07: Sheet Metal
 
 Topics:
+
 - Sheet-Metal Rules
-- Sheet-Metal Rules ändern 
+- Sheet-Metal Rules ändern
 - Flange Funktion
-- Mirror Features 
+- Mirror Features
 - Flat Pattern (Abwicklungen)
 Tutorial Session 07:
 
@@ -296,9 +281,7 @@ Materialien/Notizen:
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=8RMwlBq61vU&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-
-https://youtube.com/8RMwlBq61vU
-
+<https://youtube.com/8RMwlBq61vU>
 
 Mehr infos zur Sheetmetal-Funktion:
 
@@ -307,14 +290,15 @@ Mehr infos zur Sheetmetal-Funktion:
 - Flange-Funktion für Runde Abwicklungen
 
 ----------
-## Session 08: Flächen 
+
+## Session 08: Flächen
 
 Tutorial: (diese Woche ganz kurz)
 <iframe width="600" height="400" src="https://www.youtube.com/embed/v=rLFo0dGm-qg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-https://youtube.com/rLFo0dGm-qg
+<https://youtube.com/rLFo0dGm-qg>
 
 ----------
 
 Hilferessourcen für Fusion 360:  
-[ Offizielles Nutzungshandbuch ](https://help.autodesk.com/view/NINVFUS/DEU/)
+[Offizielles Nutzungshandbuch](https://help.autodesk.com/view/NINVFUS/DEU/)

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -1,5 +1,18 @@
 # CAD-1 - Fusion Kurs Beginner
 
+- [CAD-1 - Fusion Kurs Beginner](#cad-1---fusion-kurs-beginner)
+  - [Vorbereitung](#vorbereitung)
+  - [Session 1: Einstieg](#session-1-einstieg)
+  - [Session 02: Deep Dive “Create”](#session-02-deep-dive-create)
+  - [Session3: Patterns!](#session3-patterns)
+  - [Session 04: Create Form (Sculpting Mode)](#session-04-create-form-sculpting-mode)
+  - [Session 05: Baugruppen](#session-05-baugruppen)
+  - [Session 06: Externe Dateien und Rendern](#session-06-externe-dateien-und-rendern)
+    - [Übersicht 3D-Dateiformate](#übersicht-3d-dateiformate)
+    - [Tutorial  und Dateien:](#tutorial-und-dateien)
+  - [Session 07: Sheet Metal](#session-07-sheet-metal)
+  - [Session 08: Flächen](#session-08-flächen)
+
 ----------
 
 ## Vorbereitung

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -1,0 +1,323 @@
+# CAD-1 - Fusion Kurs Beginner
+
+- [CAD-1 - Fusion Kurs Beginner](#cad-1---fusion-kurs-beginner)
+  - [- Session 08: Flächen](#--session-08-flächen)
+  - [Vorbereitung](#vorbereitung)
+  - [Session 1: Einstieg](#session-1-einstieg)
+  - [Session 02: Deep Dive “Create”](#session-02-deep-dive-create)
+  - [Session3: Patterns!](#session3-patterns)
+  - [Session 04: Create Form (Sculpting Mode)](#session-04-create-form-sculpting-mode)
+  - [Session 05: Baugruppen](#session-05-baugruppen)
+  - [Session 06: Externe Dateien und Rendern](#session-06-externe-dateien-und-rendern)
+    - [Übersicht 3D-Dateiformate](#übersicht-3d-dateiformate)
+    - [Tutorial  und Dateien:](#tutorial--und-dateien)
+  - [Session 07: Sheet Metal](#session-07-sheet-metal)
+  - [Session 08: Flächen](#session-08-flächen)
+----------
+
+## Vorbereitung
+
+- Fusion Installieren 
+    - Autodesk Education Account
+    - Fusion 360 Download
+- Mails lesen
+
+----------
+
+## Session 1: Einstieg
+
+Lernziel: Überblick über die Fusion-Nutzungsoberfläche. Erste Geometrien Erstellen durch Skizzieren. 
+
+<iframe width="600" height="400" src="https://www.youtube.com/embed/UYnO-d12DbQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://youtube.com/UYnO-d12DbQ
+
+**Topics**: 
+
+***Nutzungsoberfläche*
+
+    - Data Panel
+    - Timeline 
+    - 3D-View
+
+**Skizzieren**
+
+    - Bemaßung
+    - Constraints
+
+**Extrudieren** 
+
+    - Join
+    - Cut
+    - 
+----------
+
+## Session 02: Deep Dive “Create”
+
+Lernziel: Verschiedene Methoden zum Geometrien erstellen  kennenlernen, weitere Skizzierungsmethoden nutzen 
+
+Topics:
+Skizzieren 
+
+    - Konstruktionsebenen + Achsen 
+    - Projektionen 
+    - (Mirror und Pattern)
+
+Create
+
+    - Extrude 
+    - Revolve 
+    - Loft
+    - Intro `Create Menu` unter `Surface` 
+    - Pattern 
+
+Meta 
+
+    - Face vs Body vs Component vs Feature
+
+Keine Angst: mein Gesicht wird im Lauf des Tutorials reduiziert, das müsst ihr nicht die ganze Session lang so groß anschauen ;)
+
+<iframe width="600" height="400" src="https://youtube.com/embed/oqnaJMujp7M" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+Hausaufgabe bis 06.11.2020: 
+    Tutorial dieser Woche Durcharbeiten
+    Karaffe nach Vorgabe modellieren mithilfe dieses Tutorials: 
+https://www.youtube.com/watch?v=auZZ_GV4q6s&
+
+<iframe width="600" height="400" src="https://youtube.com/embed/auZZ_GV4q6s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>u
+
+----------
+
+## Session3: Patterns!
+
+Lernziele: Pattern Funktion Kennenlernen in der Skizze und für Bodies, Features und Components 
+
+Einleitung: 
+
+    Reihenfolge im CAD
+    Welche Funktion nutze ich wann? 
+    Verbindung CAD-Herstellung:
+        Es lohnt sich das CAD-Modell so auf zu bauen wie es am Ende auch gefertigt wird
+    
+
+Wann nutze ich welche Pattern-Funktion?
+
+Skizze: 
+
+    - Wenn keine weiteren Anpassungen nötig sind
+    - Wenn die Skizze auf eine Oberfläche projeziert werden soll 
+    - Zum Export als DXF 
+
+Bodies: 
+
+    - um die angereihten Körper zu bearbeiten bevor sie mit cut oder join mit einem anderen Körper verbunden werden
+    - Um im Anschluss einzigartige Komponenten ab zu leiten 
+
+Feature: 
+
+    - Um einen oder mehrere Schritte aus der Timeline zu pattern
+    - Kann für jegliche Aktionen genutzt werden 
+
+Component: 
+
+    - Um das gleiche Bauteil mehrmals an zu Ordnen
+
+Tutorial: 
+
+https://www.youtube.com/watch?v=rpOxkW5eY4s&
+
+
+<iframe width="600" height="400" src="https://youtube.com/embed/rpOxkW5eY4s
+" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+----------
+
+## Session 04: Create Form (Sculpting Mode)
+
+
+<iframe width="600" height="400" src="https://youtube.com/embed/bATAm1ZuLjk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+<a data-pin-do="embedBoard" data-pin-board-width="700" data-pin-scale-height="400" data-pin-scale-width="60" href="https://www.pinterest.de/rowlllllll/organic-modelling/"></a>
+https://www.pinterest.de/rowlllllll/organic-modelling/
+Homework: 
+
+Modelliert ein Objekt nach Vorlage mit der “Create Form” - Funktion
+
+----------
+
+## Session 05: Baugruppen
+
+Lernziele: 
+Modellieren mit Baugruppen
+
+    Objekte miteinander verbinden
+    Externe Objekte in das Modell laden
+    Parameter verwenden
+
+
+
+<iframe width="600" height="400" src="https://www.youtube.com/embed/ZPyqPNb5BSI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+https://www.youtube.com/watch?v=ZPyqPNb5BSI&
+
+
+https://youtube.com/ZPyqPNb5BSI
+
+
+
+----------
+
+## Session 06: Externe Dateien und Rendern 
+
+**Lernziele/ Topics:** 
+
+Einführung: Inspect-Funktionen
+
+Externe 3D- und 2D- Modelle in Fusion Laden ([Handbuch](https://www.autodesk.com/products/fusion-360/blog/data-exchange-in-fusion-360-part-1/))
+
+Schraubenkatalog nutzen 
+
+Objekte Rendern 
+
+### Übersicht 3D-Dateiformate
+
+**Proprietäre Formate** **(Softwaregebunden)**
+
+- [Rhino](https://www.rhino3d.com/) Files (*.3dm).
+- [Autodesk Inventor](https://www.autodesk.com/products/inventor/overview) Files (*.ipt, *.iam - up to Inventor 2019)
+- [SolidWorks](https://www.solidworks.com/) Files (*.prt, *.asm, *.sldprt, *.sldasm , **.slddrw)*
+- [Autodesk Alias](https://www.autodesk.com/products/alias-products/overview?plc=ALSCPT&term=1-YEAR&support=ADVANCED&quantity=1) (*.wire)
+- [123D](https://www.autodesk.com/solutions/123d-apps) File (*.123dx)
+- [AutoCAD](https://www.autodesk.com/products/autocad/overview?support=ADVANCED) DWG Files (*.dwg)
+- [SketchUp](https://www.sketchup.com/products/sketchup-pro) Files (*.skp)
+- [CATIA ](https://www.3ds.com/de/produkte-und-services/catia/)V5 Files (*.CATProduct, *.CATPart)
+- Autodesk Fusion 360 Archive Files (*.f3d)
+- [Siemens NX](https://www.plm.automation.siemens.com/global/en/products/nx/) (*prt)
+- [Parasolid](https://de.wikipedia.org/wiki/Parasolid) Files (*.x_b, *.x_t)
+- [Pro/ENGINEER and Creo Parametric](https://www.ptc.com/en/products/creo/whats-new) Files (*.asm, *.prt)
+- [Pro/ENGINEER Granite](https://www.ptc.com/de/~/media/DE/Files/PDFs/CAD/GRANITE_Interoperability_Kernel.ashx?la=en) Files (*.g)
+- [Pro/ENGINEER Neutral](http://support.ptc.com/help/creo/creo_pma/usascii/index.html#page/data_exchange/interface/About_Part_and_Assembly_Neutral_Files.html) Files(*.neu)
+- Autodesk Fusion 360 Toolpath Archive Files (*.cam360)
+- [Blender](https://www.blender.org/) File (.blend)
+
+[Super Nützlicher CAD Conversion Finder ](https://www.cadforum.cz/cadforum_en/formats.asp)
+
+[Noch Mehr CAD und 3D-Programme](https://en.wikipedia.org/wiki/Comparison_of_computer-aided_design_software)
+
+**Interchange Formate (unabhängig von Software):**
+
+| Format                                     | Ending                      | Type                | Additional Data                                                                                                                                                                                                                                                           | Notes                                 |
+| ------------------------------------------ | --------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| STEP                                       | .stp / .step                | BREP<br>Surfaces    | Different additional  data according to Standards                                                                                                                                                                                                                         | Most standard file format             |
+| IGES                                       | .igs / .iges                | BREP<br>Surfaces    | circuit diagrams, wireframe, freeform surface or solid modeling representations                                                                                                                                                                                           | Not updated since 1994                |
+| Wavefront OBJ                              | .obj                        | Both Mesh and Nurbs | Texture                                                                                                                                                                                                                                                                   |                                       |
+| AMF                                        | .amf                        | Mesh                | color, materials, lattices, and constellations                                                                                                                                                                                                                            |                                       |
+| Collada                                    | .dae                        | Mesh                | Colors, Textures, Collaborative, Physics, Animations                                                                                                                                                                                                                      |                                       |
+| 3MF                                        | .3mf                        | Mesh                | Full color and texture support in a single file<br>Support structures attached to part data<br>Full tray support for direct machine preparation<br>Efficient storage of beam lattices<br>Multiple material support<br>Native integration in Microsoft Office and Paint 3D | Designed for industrial manufacturing |
+| STL - Stereolithography                    | .stl                        | Mesh                | No additional information                                                                                                                                                                                                                                                 |                                       |
+| Polygon File Format (Pointcloud)           | .ply                        | Mesh                | color and transparency, surface normals, texture coordinates and data confidence values                                                                                                                                                                                   |                                       |
+| VRML-<br>Virtual Reality Modeling Language | .wrl<br>.wrz                | Mesh                |                                                                                                                                                                                                                                                                           |                                       |
+| X3D                                        | .x3d<br>.x3dv, .x3db, .x3dz |                     | Geospatial<br>Animation<br>NURBS                                                                                                                                                                                                                                          |                                       |
+| ACIS - SAT/SMT                             | .sat                        | BREP<br>Surfaces    | integrates wireframe model, surface, and solid modeling functionality with both manifold and non-manifold topology, and a rich set of geometric operations.                                                                                                               |                                       |
+| DXF<br>(Drawing Exchange Format)           | .dxf                        | 2D Paths            |                                                                                                                                                                                                                                                                           |                                       |
+|                                            |                             |                     |                                                                                                                                                                                                                                                                           |                                       |
+
+Alle Dateiformate die Fusion einlesen und umwandeln kann:
+https://knowledge.autodesk.com/support/fusion-360/troubleshooting/caas/sfdcarticles/sfdcarticles/File-formats-supported-by-Fusion-360.html
+
+Leitfaden Dateiexport: 
+Immer die Ursprungsdatei mit exportieren um keine Informationen zu verlieren. 
+Nach Möglichkeit und Verwendungszweck verschiedene Interchange Formate mitliefern.
+Nützliches Tool um zu sehen welche Programme welche Formate öffnen können: Cadforum.cz
+
+
+### Tutorial  und Dateien: 
+
+Solidworks Dateien Download
+https://www.dropbox.com/sh/usd62jexewc6ggp/AACkJ-t9Tnk_LFQl1eQxe7Uda?dl=0
+
+
+
+
+<iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=6O-ftuqFnmI&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://youtube.com/6O-ftuqFnmI
+ 
+ Links:
+ Kostenlose HDRIs:
+
+    - HDRI-Haven: https://hdrihaven.com/
+    - Maximeroz: https://www.maximeroz.com/hdri-free-pack
+    - viz- people: https://www.viz-people.com/portfolio/free-hdri-maps/
+    - openfootage: https://www.openfootage.net/hdri-panorama/ (kostenlos in der niedrigen Auflösung)
+    - Eisklotz.de: https://www.eisklotz.com/products/hdri/
+
+Webseiten zum Download von 3D-Modellen:
+
+- https://grabcad.com/
+- https://gallery.autodesk.com/
+- https://b2b.partcommunity.com/community/
+- https://www.traceparts.com/en
+- https://www.3dcontentcentral.com/
+- https://www.turbosquid.com/Search/3D-Models/free/cad
+
+ 
+
+ Homework bis 18.12.: 
+- Ladet euch ein oder mehrere HDRIs runter
+- Sucht nach interessanten / passenden / witzigen 3D-modellen im Internet oder modelliert selbst welche.
+- Importiert die Modelle in Fusion (In einen Unterordner in eurem Persönlichen Ordner!) und bearbeitet sie falls nötig. 
+- Erstellt interessante (Chaos-) Renderings mit den HDRIs, Modellen und interessanten Materialkombinationen. 
+- Nutzt euer gestalterisches Gespür um eine cooles Bild zu erzeugen 
+
+Nochmal eine Kurzinfo zur Hausaufgabe inklusive kleinem Beispiel
+
+
+<iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=JrCm6O7inho&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://youtube.com/JrCm6O7inho
+
+----------
+
+## Session 07: Sheet Metal 
+
+
+Topics:
+- Sheet-Metal Rules
+- Sheet-Metal Rules ändern 
+- Flange Funktion
+- Mirror Features 
+- Flat Pattern (Abwicklungen)
+Tutorial Session 07:
+
+Materialien/Notizen:
+
+- Flasche zum Einfügen
+- Link zu meinem Modell (als Referenz wenn etwas bei euch nicht funktioniert)
+
+<iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=8RMwlBq61vU&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+https://youtube.com/8RMwlBq61vU
+
+
+Mehr infos zur Sheetmetal-Funktion:
+
+- Advanced Tutorial - Sheetmetal (in Englisch)
+- Blechfunktion im Fusion 360 Nutzungshandbuch  (Deutsch / Englisch)
+- Flange-Funktion für Runde Abwicklungen
+
+----------
+## Session 08: Flächen 
+
+Tutorial: (diese Woche ganz kurz)
+<iframe width="600" height="400" src="https://www.youtube.com/embed/v=rLFo0dGm-qg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://youtube.com/rLFo0dGm-qg
+
+----------
+
+Hilferessourcen für Fusion 360:  
+[ Offizielles Nutzungshandbuch ](https://help.autodesk.com/view/NINVFUS/DEU/)

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -31,7 +31,7 @@ Lernziel: Überblick über die Fusion-Nutzungsoberfläche. Erste Geometrien Erst
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/UYnO-d12DbQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/UYnO-d12DbQ>
+<https://youtube.com/watch/UYnO-d12DbQ>
 
 **Topics**:
 
@@ -154,7 +154,7 @@ Lernziele:
 <iframe width="600" height="400" src="https://www.youtube.com/embed/ZPyqPNb5BSI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 https://www.youtube.com/watch?v=ZPyqPNb5BSI&
 
-<https://youtube.com/ZPyqPNb5BSI>
+<https://youtube.com/watch/ZPyqPNb5BSI>
 
 ----------
 
@@ -228,7 +228,7 @@ Solidworks Dateien Download
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=6O-ftuqFnmI&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/6O-ftuqFnmI>
+<https://youtube.com/watch/6O-ftuqFnmI>
 
  Links:
  Kostenlose HDRIs:
@@ -260,7 +260,7 @@ Nochmal eine Kurzinfo zur Hausaufgabe inklusive kleinem Beispiel
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=JrCm6O7inho&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/JrCm6O7inho>
+<https://youtube.com/watch/JrCm6O7inho>
 
 ----------
 
@@ -282,7 +282,7 @@ Materialien/Notizen:
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=8RMwlBq61vU&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/8RMwlBq61vU>
+<https://youtube.com/watch/8RMwlBq61vU>
 
 Mehr infos zur Sheetmetal-Funktion:
 
@@ -297,7 +297,7 @@ Mehr infos zur Sheetmetal-Funktion:
 Tutorial: (diese Woche ganz kurz)
 <iframe width="600" height="400" src="https://www.youtube.com/embed/v=rLFo0dGm-qg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/rLFo0dGm-qg>
+<https://youtube.com/watch/rLFo0dGm-qg>
 
 ----------
 

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -1,7 +1,6 @@
 # CAD-1 - Fusion Kurs Beginner
 
 - [CAD-1 - Fusion Kurs Beginner](#cad-1---fusion-kurs-beginner)
-  - [- Session 08: Flächen](#--session-08-flächen)
   - [Vorbereitung](#vorbereitung)
   - [Session 1: Einstieg](#session-1-einstieg)
   - [Session 02: Deep Dive “Create”](#session-02-deep-dive-create)
@@ -10,13 +9,12 @@
   - [Session 05: Baugruppen](#session-05-baugruppen)
   - [Session 06: Externe Dateien und Rendern](#session-06-externe-dateien-und-rendern)
     - [Übersicht 3D-Dateiformate](#übersicht-3d-dateiformate)
-    - [Tutorial  und Dateien:](#tutorial--und-dateien)
+    - [Tutorial  und Dateien:](#tutorial-und-dateien)
   - [Session 07: Sheet Metal](#session-07-sheet-metal)
   - [Session 08: Flächen](#session-08-flächen)
 
 ----------
 
-<!-- markdownlint-disable no-emphasis-as-header -->
 ## Vorbereitung
 
 - Fusion Installieren
@@ -31,22 +29,20 @@ Lernziel: Überblick über die Fusion-Nutzungsoberfläche. Erste Geometrien Erst
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/UYnO-d12DbQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/watch/UYnO-d12DbQ>
+### Topics
 
-**Topics**:
-
-**Nutzungsoberfläche**
+#### Nutzungoberfläche
 
     - Data Panel
     - Timeline 
     - 3D-View
 
-**Skizzieren**
+#### Skizzieren
 
     - Bemaßung
     - Constraints
 
-**Extrudieren**
+#### Extrudieren
 
     - Join
     - Cut
@@ -56,14 +52,17 @@ Lernziel: Überblick über die Fusion-Nutzungsoberfläche. Erste Geometrien Erst
 
 Lernziel: Verschiedene Methoden zum Geometrien erstellen  kennenlernen, weitere Skizzierungsmethoden nutzen
 
-Topics:
-**Skizzieren**
+<!-- markdownlint-disable no-duplicate-heading -->
+### Topics
+
+#### Skizzieren
 
     - Konstruktionsebenen + Achsen 
     - Projektionen 
     - (Mirror und Pattern)
 
-**Create**
+<!-- markdownlint-enable no-duplicate-heading -->
+#### Create
 
     - Extrude 
     - Revolve 
@@ -71,18 +70,15 @@ Topics:
     - Intro `Create Menu` unter `Surface` 
     - Pattern 
 
-**Meta**
+#### Meta
 
     - Face vs Body vs Component vs Feature
-
-Keine Angst: mein Gesicht wird im Lauf des Tutorials reduiziert, das müsst ihr nicht die ganze Session lang so groß anschauen ;)
 
 <iframe width="600" height="400" src="https://youtube.com/embed/oqnaJMujp7M" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Hausaufgabe
     Tutorial dieser Woche Durcharbeiten
     Karaffe nach Vorgabe modellieren mithilfe dieses Tutorials:
-<https://www.youtube.com/watch?v=auZZ_GV4q6s>&
 
 <iframe width="600" height="400" src="https://youtube.com/embed/auZZ_GV4q6s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>u
 
@@ -99,7 +95,7 @@ Einleitung:
     Verbindung CAD-Herstellung:
         Es lohnt sich das CAD-Modell so auf zu bauen wie es am Ende auch gefertigt wird
 
-**Wann nutze ich welche Pattern-Funktion?**
+### Wann nutze ich welche Pattern-Funktion?
 
 Skizze:
 
@@ -121,9 +117,7 @@ Component:
 
     - Um das gleiche Bauteil mehrmals an zu Ordnen
 
-**Tutorial:**
-
-<https://www.youtube.com/watch?v=rpOxkW5eY4s>&
+#### Tutorial
 
 <iframe width="600" height="400" src="https://youtube.com/embed/rpOxkW5eY4s
 " frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -144,23 +138,21 @@ Modelliert ein Objekt nach Vorlage mit der “Create Form” - Funktion
 
 ## Session 05: Baugruppen
 
-Lernziele:
-**Modellieren mit Baugruppen**
+### Lernziele
+
+#### Modellieren mit Baugruppen
 
     Objekte miteinander verbinden
     Externe Objekte in das Modell laden
     Parameter verwenden
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/ZPyqPNb5BSI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-https://www.youtube.com/watch?v=ZPyqPNb5BSI&
-
-<https://youtube.com/watch/ZPyqPNb5BSI>
 
 ----------
 
 ## Session 06: Externe Dateien und Rendern
 
-**Lernziele/ Topics:**
+### Lernziele/ Topics
 
 - Einführung: Inspect-Funktionen
 
@@ -179,9 +171,7 @@ Solidworks Dateien Download
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=6O-ftuqFnmI&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/watch/6O-ftuqFnmI>
-
- Links:
+###  Links:
  Kostenlose HDRIs:
 
     - HDRI-Haven: https://hdrihaven.com/
@@ -211,8 +201,6 @@ Nochmal eine Kurzinfo zur Hausaufgabe inklusive kleinem Beispiel
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=JrCm6O7inho&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/watch/JrCm6O7inho>
-
 ----------
 
 ## Session 07: Sheet Metal
@@ -233,8 +221,6 @@ Materialien/Notizen:
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=8RMwlBq61vU&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/watch/8RMwlBq61vU>
-
 Mehr infos zur Sheetmetal-Funktion:
 
 - Advanced Tutorial - Sheetmetal (in Englisch)
@@ -248,10 +234,8 @@ Mehr infos zur Sheetmetal-Funktion:
 Tutorial: (diese Woche ganz kurz)
 <iframe width="600" height="400" src="https://www.youtube.com/embed/v=rLFo0dGm-qg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtube.com/watch/rLFo0dGm-qg>
-
 ----------
 
-<!-- markdownlint-enable no-emphasis-as-header -->
 Hilferessourcen für Fusion 360:  
 [Offizielles Nutzungshandbuch](https://help.autodesk.com/view/NINVFUS/DEU/)
+

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -1,18 +1,5 @@
 # CAD-1 - Fusion Kurs Beginner
 
-- [CAD-1 - Fusion Kurs Beginner](#cad-1---fusion-kurs-beginner)
-  - [Vorbereitung](#vorbereitung)
-  - [Session 1: Einstieg](#session-1-einstieg)
-  - [Session 02: Deep Dive “Create”](#session-02-deep-dive-create)
-  - [Session3: Patterns!](#session3-patterns)
-  - [Session 04: Create Form (Sculpting Mode)](#session-04-create-form-sculpting-mode)
-  - [Session 05: Baugruppen](#session-05-baugruppen)
-  - [Session 06: Externe Dateien und Rendern](#session-06-externe-dateien-und-rendern)
-    - [Übersicht 3D-Dateiformate](#übersicht-3d-dateiformate)
-    - [Tutorial  und Dateien:](#tutorial-und-dateien)
-  - [Session 07: Sheet Metal](#session-07-sheet-metal)
-  - [Session 08: Flächen](#session-08-flächen)
-
 ----------
 
 ## Vorbereitung

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -18,9 +18,8 @@
 ## Vorbereitung
 
 - Fusion Installieren 
-    - Autodesk Education Account
-    - Fusion 360 Download
-- Mails lesen
+    - [ Autodesk Education Account ](https://accounts.autodesk.com/register)
+    - [ Fusion 360 Download ](https://www.autodesk.com/education/edu-software/overview?sorting=featured&page=1&filters=pdm-products,individual#card-f360b)
 
 ----------
 
@@ -34,7 +33,7 @@ https://youtube.com/UYnO-d12DbQ
 
 **Topics**: 
 
-***Nutzungsoberfläche*
+**Nutzungsoberfläche**
 
     - Data Panel
     - Timeline 
@@ -49,7 +48,6 @@ https://youtube.com/UYnO-d12DbQ
 
     - Join
     - Cut
-    - 
 ----------
 
 ## Session 02: Deep Dive “Create”
@@ -57,13 +55,13 @@ https://youtube.com/UYnO-d12DbQ
 Lernziel: Verschiedene Methoden zum Geometrien erstellen  kennenlernen, weitere Skizzierungsmethoden nutzen 
 
 Topics:
-Skizzieren 
+**Skizzieren** 
 
     - Konstruktionsebenen + Achsen 
     - Projektionen 
     - (Mirror und Pattern)
 
-Create
+**Create**
 
     - Extrude 
     - Revolve 
@@ -71,7 +69,7 @@ Create
     - Intro `Create Menu` unter `Surface` 
     - Pattern 
 
-Meta 
+**Meta** 
 
     - Face vs Body vs Component vs Feature
 
@@ -80,7 +78,7 @@ Keine Angst: mein Gesicht wird im Lauf des Tutorials reduiziert, das müsst ihr 
 <iframe width="600" height="400" src="https://youtube.com/embed/oqnaJMujp7M" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
-Hausaufgabe bis 06.11.2020: 
+Hausaufgabe
     Tutorial dieser Woche Durcharbeiten
     Karaffe nach Vorgabe modellieren mithilfe dieses Tutorials: 
 https://www.youtube.com/watch?v=auZZ_GV4q6s&
@@ -99,9 +97,8 @@ Einleitung:
     Welche Funktion nutze ich wann? 
     Verbindung CAD-Herstellung:
         Es lohnt sich das CAD-Modell so auf zu bauen wie es am Ende auch gefertigt wird
-    
 
-Wann nutze ich welche Pattern-Funktion?
+**Wann nutze ich welche Pattern-Funktion?**
 
 Skizze: 
 
@@ -123,7 +120,7 @@ Component:
 
     - Um das gleiche Bauteil mehrmals an zu Ordnen
 
-Tutorial: 
+**Tutorial:** 
 
 https://www.youtube.com/watch?v=rpOxkW5eY4s&
 
@@ -151,7 +148,7 @@ Modelliert ein Objekt nach Vorlage mit der “Create Form” - Funktion
 ## Session 05: Baugruppen
 
 Lernziele: 
-Modellieren mit Baugruppen
+**Modellieren mit Baugruppen**
 
     Objekte miteinander verbinden
     Externe Objekte in das Modell laden

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -16,6 +16,7 @@
 
 ----------
 
+<!-- markdownlint-disable no-emphasis-as-header -->
 ## Vorbereitung
 
 - Fusion Installieren
@@ -300,5 +301,6 @@ Tutorial: (diese Woche ganz kurz)
 
 ----------
 
+<!-- markdownlint-enable no-emphasis-as-header -->
 Hilferessourcen für Fusion 360:  
 [Offizielles Nutzungshandbuch](https://help.autodesk.com/view/NINVFUS/DEU/)

--- a/docs/CAD/fusion360course/CAD1-beginner.md
+++ b/docs/CAD/fusion360course/CAD1-beginner.md
@@ -171,7 +171,8 @@ Solidworks Dateien Download
 
 <iframe width="600" height="400" src="https://www.youtube.com/embed/watch?v=6O-ftuqFnmI&" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-###  Links:
+### Links
+
  Kostenlose HDRIs:
 
     - HDRI-Haven: https://hdrihaven.com/
@@ -238,4 +239,3 @@ Tutorial: (diese Woche ganz kurz)
 
 Hilferessourcen für Fusion 360:  
 [Offizielles Nutzungshandbuch](https://help.autodesk.com/view/NINVFUS/DEU/)
-

--- a/docs/CAD/fusion360course/CAD2-advanced.md
+++ b/docs/CAD/fusion360course/CAD2-advanced.md
@@ -10,195 +10,186 @@
 - [Session 07: Add-Ins/Scripts + Wiederholung Baugruppen](#session-07-add-insscripts--wiederholung-baugruppen)
 - [Session 08: The Lost lecture](#session-08-the-lost-lecture)
 
-# Vorbereitung
+## Vorbereitung
 
-- [Fusion Installieren ](https://www.autodesk.com/education/edu-software/overview?sorting=featuredpage=1filters=individualsearch=FUSION)
-- Mails lesen 
+- [Fusion Installieren](https://www.autodesk.com/education/edu-software/overview?sorting=featuredpage=1filters=individualsearch=FUSION)
+- Mails lesen
 
-# Session 1: Recap
+## Session 1: Recap
 
-**Lernziel:** Gesamtüberblick über Fusion (wieder-) bekommen. Bekannte Funktionen richtig nutzen. Begriffe kennenlernen. 
-
+**Lernziel:** Gesamtüberblick über Fusion (wieder-) bekommen. Bekannte Funktionen richtig nutzen. Begriffe kennenlernen.
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/ikiBYJz1tbA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 https://youtu.be/ikiBYJz1tbA
 
-Topics: 
+Topics:
 
-**Skizzieren** 
+**Skizzieren**
 
-- - Bemaßungen 
-  - Constraints
-  - Projektion
-  - Mirror
+- Bemaßungen
+- Constraints
+- Projektion
+- Mirror
 
-**Geometrie erzeugen** 
+**Geometrie erzeugen**
 
-- Extrude 
+- Extrude
   - Extrude Surface
 
 **Simple Joints**
 
-# Session 2: Create Geometry 
+## Session 2: Create Geometry
 
 ![img](https://i.pinimg.com/564x/4b/bc/98/4bbc98fc32dcc1c33c8f23b39be47919.jpg)
 
- Lernziele: 
+ Lernziele:
 
-- Geometrieerstellung üben 
-- Best Practices einhalten 
-- Nach Referenz Modellieren 
- Topics: 
+- Geometrieerstellung üben
+- Best Practices einhalten
+- Nach Referenz Modellieren
+ Topics:
 
-**Skizzieren** 
+**Skizzieren**
 
-- - Canvas als Referenz
-  - Plane along Path
-  - Plane at angle 
-  - Fillets 
-  - Project to surface
-  - Pattern
+- Canvas als Referenz
+- Plane along Path
+- Plane at angle
+- Fillets
+- Project to surface
+- Pattern
 
 **Create / Modify**
 
-- - Revolve / Loft / Sweep
-  - Mirror / Pattern
-  - Shell
+- Revolve / Loft / Sweep
+- Mirror / Pattern
+- Shell
 
  Tutorial Session 02
-
-Wir treffen uns 13:45 wieder im Googlemeet
-
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/NjqGgR21fpI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 https://youtu.be/NjqGgR21fpI
 
-**Problemlösungen:** 
+**Problemlösungen:**
 
-Wandstärke nicht einstellbar (Shell-Funktion am Ausguss): https://youtu.be/JYpVVjVQE-g
+Wandstärke nicht einstellbar (Shell-Funktion am Ausguss): <https://youtu.be/JYpVVjVQE-g>
 
- Homework: 
+ Homework:
 
-Tasse Modellieren nach Referenz : 
+Tasse Modellieren nach Referenz :
 
-Link zum Bild: https://a360.co/3dUx4VU
+Link zum Bild: <https://a360.co/3dUx4VU>
 
-# Session 3: Assembly Deep-Dive
+## Session 3: Assembly Deep-Dive
 
- Topics: 
+ Topics:
 
-**Joints** 
+**Joints**
 
 ![img](https://i.pinimg.com/564x/18/99/ff/1899ff2dfc717c16a6489552af258c2a.jpg)
 
-- - as-built Joint
+  - as-built Joint
   - Joints
-  - - Rotate
+    -  Rotate
     - Pin-Slot
-  - Design Approaches: 
-  - - Bottom-up 
+  - Design Approaches:
+    - Bottom-up
     - Top-Down
 
 **Sonstiges**
 
-- - [Paste vs Paste-New](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-9EDE876B-6A97-47E9-AB87-F27ADFFDCEE9)
+  - [Paste vs Paste-New](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-9EDE876B-6A97-47E9-AB87-F27ADFFDCEE9)
   - Delete vs Remove
 
- Tutorial: 
-
+ Tutorial:
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/em0-RvzwQXo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 https://youtu.be/em0-RvzwQXo
 
- Homework: 
+ Homework:
 
 dieses Kurz-Tutorial durcharbeiten.
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/eRUv6s5Jgi8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
+<https://youtu.be/eRUv6s5Jgi8>
 
-https://youtu.be/eRUv6s5Jgi8
-
- Notizen: 
+ Notizen:
 
 Hier findet ihr eine gute Übersicht über alle Joint Arten: [Video](https://www.youtube.com/Bw08O6XsfDIfeature=emb_titleab_channel=NYCCNC)
 
-# Session 04: Create Form (Sculpting Mode)
+## Session 04: Create Form (Sculpting Mode)
 
  Tutorial Session 04:
 
-
 <iframe width="700" height="400" src="https://www.youtube.com/embed/bATAm1ZuLjk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-https://youtu.be/bATAm1ZuLjk
+<https://youtu.be/bATAm1ZuLjk>
 
-https://www.pinterest.de/rowlllllll/organic-modelling/
+<https://www.pinterest.de/rowlllllll/organic-modelling/>
 
 <div>
 <a data-pin-do="embedBoard" data-pin-board-width="700" data-pin-scale-height="400" data-pin-scale-width="60" href="https://www.pinterest.de/rowlllllll/organic-modelling/"></a>
 </div>
-Homework: 
+Homework:
 
-Modelliert ein Objekt nach Vorlage mit der “Create Form” - Funktion und Rendert es anschließend in Fusion. 
+Modelliert ein Objekt nach Vorlage mit der “Create Form” - Funktion und Rendert es anschließend in Fusion.
 
-Schaut euch Dazu noch dieses Tutorial an in dem ich euch ein paar Tipps gebe wie ihr in Fusion Rendern könnt. Ich zeige auch ein paar Funktionen die ihr noch 
+Schaut euch Dazu noch dieses Tutorial an in dem ich euch ein paar Tipps gebe wie ihr in Fusion Rendern könnt. Ich zeige auch ein paar Funktionen die ihr noch
 
 Kostenlose HDRIs (wird im Tutorial erklärt):
 
-- - **Maximeroz:** https://www.maximeroz.com/hdri-free-pack
-  - **HDRI-Haven:** https://hdrihaven.com/
-  - **viz- people:** https://www.viz-people.com/portfolio/free-hdri-maps/
-  - **openfootage:** https://www.openfootage.net/hdri-panorama/ (kostenlos in der niedrigen Auflösung)
-  - **Eisklotz.de**: https://www.eisklotz.com/products/hdri/
-
+- **Maximeroz:** <https://www.maximeroz.com/hdri-free-pack>
+- **HDRI-Haven:** <https://hdrihaven.com/>
+- **viz- people:** <https://www.viz-people.com/portfolio/free-hdri-maps/>
+- **openfootage:** <https://www.openfootage.net/hdri-panorama/> (kostenlos in der niedrigen Auflösung)
+- **Eisklotz.de**: <https://www.eisklotz.com/products/hdri/>
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/rhY-p0IJlw8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-https://youtu.be/rhY-p0IJlw8
+<https://youtu.be/rhY-p0IJlw8>
 
-# Session 05: Parametrik und Blechbearbeitung
+## Session 05: Parametrik und Blechbearbeitung
 
-**Inhalte:** 
+**Inhalte:**
 
-[Parametrik ](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-76272551-3275-46C4-AE4D-10D58B408C20)
+[Parametrik](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-76272551-3275-46C4-AE4D-10D58B408C20)
 
-[Blechfunktion ](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-309ACAF1-59BC-4CF0-9D14-98BA5EDC2685)
+[Blechfunktion](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-309ACAF1-59BC-4CF0-9D14-98BA5EDC2685)
 
  Tutorial Session 05:
 
-
 <iframe width="700" height="400" src="https://www.youtube.com/embed/3j68V_jSpLM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-https://youtu.be/3j68V_jSpLM
+<https://youtu.be/3j68V_jSpLM>
 
-**Homework:** 
+**Homework:**
 
 - Tutorial fertig arbeiten
 
-# Session 06: 3D Formate und Zeichnungen
+## Session 06: 3D Formate und Zeichnungen
 
  Übersicht 3D-Dateiformate
 
 **Proprietäre Formate** **(Softwaregebunden)**
 
 - [Rhino](https://www.rhino3d.com/) Files (*.3dm).
-- [Autodesk Inventor](https://www.autodesk.com/products/inventor/overview) Files (*.ipt, *.iam - up to Inventor 2019)
-- [SolidWorks](https://www.solidworks.com/) Files (*.prt, *.asm, *.sldprt, *.sldasm , **.slddrw)*
+- [Autodesk Inventor](https://www.autodesk.com/products/inventor/overview) Files (*.ipt,*.iam - up to Inventor 2019)
+- [SolidWorks](https://www.solidworks.com/) Files (*.prt,*.asm, *.sldprt,*.sldasm , **.slddrw)*
 - [Autodesk Alias](https://www.autodesk.com/products/alias-products/overview?plc=ALSCPTterm=1-YEARsupport=ADVANCEDquantity=1) (*.wire)
 - [123D](https://www.autodesk.com/solutions/123d-apps) File (*.123dx)
 - [AutoCAD](https://www.autodesk.com/products/autocad/overview?support=ADVANCED) DWG Files (*.dwg)
 - [SketchUp](https://www.sketchup.com/products/sketchup-pro) Files (*.skp)
-- [CATIA ](https://www.3ds.com/de/produkte-und-services/catia/)V5 Files (*.CATProduct, *.CATPart)
+- [CATIA](https://www.3ds.com/de/produkte-und-services/catia/)V5 Files (*.CATProduct,*.CATPart)
 - Autodesk Fusion 360 Archive Files (*.f3d)
 - [Siemens NX](https://www.plm.automation.siemens.com/global/en/products/nx/) (*prt)
-- [Parasolid](https://de.wikipedia.org/wiki/Parasolid) Files (*.x_b, *.x_t)
-- [Pro/ENGINEER and Creo Parametric](https://www.ptc.com/en/products/creo/whats-new) Files (*.asm, *.prt)
+- [Parasolid](https://de.wikipedia.org/wiki/Parasolid) Files (*.x_b,*.x_t)
+- [Pro/ENGINEER and Creo Parametric](https://www.ptc.com/en/products/creo/whats-new) Files (*.asm,*.prt)
 - [Pro/ENGINEER Granite](https://www.ptc.com/de/~/media/DE/Files/PDFs/CAD/GRANITE_Interoperability_Kernel.ashx?la=en) Files (*.g)
 - [Pro/ENGINEER Neutral](http://support.ptc.com/help/creo/creo_pma/usascii/index.html#page/data_exchange/interface/About_Part_and_Assembly_Neutral_Files.html) Files(*.neu)
 - Autodesk Fusion 360 Toolpath Archive Files (*.cam360)
 - [Blender](https://www.blender.org/) File (.blend)
 
-[Super Nützlicher CAD Conversion Finder ](https://www.cadforum.cz/cadforum_en/formats.asp)
+[Super Nützlicher CAD Conversion Finder](https://www.cadforum.cz/cadforum_en/formats.asp)
 
 [Noch Mehr CAD und 3D-Programme](https://en.wikipedia.org/wiki/Comparison_of_computer-aided_design_software)
 **Interchange Formate** **(unabhängig** **von Software):**
@@ -214,17 +205,17 @@ https://youtu.be/3j68V_jSpLM
 | [STL - Stereolithography](https://en.wikipedia.org/wiki/STL_(file_format)) | .stl                    | Mesh                                                         | No additional information                                    |         |                                       |
 | [Polygon File Format](https://en.wikipedia.org/wiki/PLY_(file_format)) (Pointcloud) | .ply                    | Mesh                                                         | color and transparency, surface normals, texture coordinates and data confidence values |         |                                       |
 | [VRML-](https://en.wikipedia.org/wiki/VRML)[Virtual Reality Modeling Language](https://en.wikipedia.org/wiki/VRML) | .wrl.wrz                | Mesh                                                         |                                                              |         |                                       |
-| [X3D ](https://en.wikipedia.org/wiki/X3D)                    | .x3d.x3dv, .x3db, .x3dz |                                                              | [Geospatial](https://en.wikipedia.org/wiki/Geospatial)AnimationNURBS |         |                                       |
+| [X3D](https://en.wikipedia.org/wiki/X3D)                    | .x3d.x3dv, .x3db, .x3dz |                                                              | [Geospatial](https://en.wikipedia.org/wiki/Geospatial)AnimationNURBS |         |                                       |
 | [ACIS - SAT/SMT](https://en.wikipedia.org/wiki/ACIS)         | .sat                    | [BREP](https://en.wikipedia.org/wiki/Boundary_representation)Surfaces | integrates [wireframe model](https://en.wikipedia.org/wiki/Wireframe_model), [surface](https://en.wikipedia.org/wiki/Surface_(topology)), and [solid modeling](https://en.wikipedia.org/wiki/Solid_modeling) functionality with both [manifold and non-manifold topology](https://en.wikipedia.org/wiki/List_of_manifolds), and a rich set of geometric operations. |         |                                       |
 | [DXF](https://en.wikipedia.org/wiki/AutoCAD_DXF)[(Drawing Exchange Format)](https://en.wikipedia.org/wiki/AutoCAD_DXF) | .dxf                    | 2D Paths                                                     |                                                              |         |                                       |
 
 Alle Dateiformate die Fusion einlesen und umwandeln kann:
 
-https://knowledge.autodesk.com/support/fusion-360/troubleshooting/caas/sfdcarticles/sfdcarticles/File-formats-supported-by-Fusion-360.html
+<https://knowledge.autodesk.com/support/fusion-360/troubleshooting/caas/sfdcarticles/sfdcarticles/File-formats-supported-by-Fusion-360.html>
 
-**Leitfaden Dateiexport:** 
+**Leitfaden Dateiexport:**
 
-Immer die Ursprungsdatei mit exportieren um keine Informationen zu verlieren. 
+Immer die Ursprungsdatei mit exportieren um keine Informationen zu verlieren.
 
 Nach Möglichkeit und Verwendungsyweck verschiedene Interchange-Formate mitliefern.
 
@@ -232,84 +223,81 @@ Nach Möglichkeit und Verwendungsyweck verschiedene Interchange-Formate mitliefe
 
 Link zur Solidworks Datei
 
-https://www.dropbox.com/sh/usd62jexewc6ggp/AACkJ-t9Tnk_LFQl1eQxe7Uda?dl=0
-
+<https://www.dropbox.com/sh/usd62jexewc6ggp/AACkJ-t9Tnk_LFQl1eQxe7Uda?dl=0>
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/w5eAMIv4M9A" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-https://youtu.be/w5eAMIv4M9A
+<https://youtu.be/w5eAMIv4M9A>
 
  Homework:
 
-Ladet euch auf einer Seite wie Grabcad ein 3D Modell mit mindestens 4 Körpern/Komponeneten herunter und erstellt eine mehrseitige technische Zeichung mit allen nötigen Maßen, einer Explosionsansicht der Einzelteile sowie einer Übersicht von Objekten aus gleichem Material (Schnittplan). 
+Ladet euch auf einer Seite wie Grabcad ein 3D Modell mit mindestens 4 Körpern/Komponeneten herunter und erstellt eine mehrseitige technische Zeichung mit allen nötigen Maßen, einer Explosionsansicht der Einzelteile sowie einer Übersicht von Objekten aus gleichem Material (Schnittplan).
 
 Webseiten zum Download von 3D-Modellen:
 
 - [https://grabcad.com/](https://grabcad.com/library)
-- https://gallery.autodesk.com/
-- https://b2b.partcommunity.com/community/
-- https://www.traceparts.com/en
-- https://www.3dcontentcentral.com/
-- https://www.turbosquid.com/Search/3D-Models/free/cad
+- <https://gallery.autodesk.com/>
+- <https://b2b.partcommunity.com/community/>
+- <https://www.traceparts.com/en>
+- <https://www.3dcontentcentral.com/>
+- <https://www.turbosquid.com/Search/3D-Models/free/cad>
 
-# Session 07: Add-Ins/Scripts + Wiederholung Baugruppen
+## Session 07: Add-Ins/Scripts + Wiederholung Baugruppen
 
  **Topics:**
 
-- [Autodesk Fusion 360 App Store](https://apps.autodesk.com/FUSION/en/Home/Index)  ([Nutzungshinweise](https://apps.autodesk.com/en/Public/FAQ)[ und FAQ](https://apps.autodesk.com/en/Public/FAQ))
+- [Autodesk Fusion 360 App Store](https://apps.autodesk.com/FUSION/en/Home/Index)  ([Nutzungshinweise](https://apps.autodesk.com/en/Public/FAQ)[und FAQ](https://apps.autodesk.com/en/Public/FAQ))
 - Unterschied: Script vs ADD-IN
 - ADD-INs in Fusion aktivieren
 - Zahnräder erstellen mit dem [HG+](https://apps.autodesk.com/FUSION/en/Detail/Index?id=1259509007239787473appLang=enos=Mac) ADD-In
 - Joints Platzieren
   - Unterschied: [**Joint**](https://help.autodesk.com/view/fusion360/ENU/?guid=ASM-JOINT-COMMAND) vs [**As-Built-Joint**](https://help.autodesk.com/view/fusion360/ENU/?guid=ASM-AS-BUILT-JOINT-COMMAND)   (DE: [**Gelenk**](https://help.autodesk.com/view/NINVFUS/DEU/?guid=ASM-JOINT-COMMAND) vs [**Verbinden wie Modelliert**](https://help.autodesk.com/view/NINVFUS/DEU/?guid=ASM-AS-BUILT-JOINT-COMMAND)**)**
-  - Motion Links setzen und definieren 
+  - Motion Links setzen und definieren
 
  Tutorial Session 07:
 
-Link zum [**Autodesk Fusion 360 App Store**](https://apps.autodesk.com/FUSION/en/Home/Index) 
+Link zum [**Autodesk Fusion 360 App Store**](https://apps.autodesk.com/FUSION/en/Home/Index)
 
 - **Erwähnte Add-Ins** **(Apps):**
 
-- - [Helical Gear Pkus](https://apps.autodesk.com/FUSION/en/Detail/Index?id=1259509007239787473appLang=enos=Mac)
+  - [Helical Gear Pkus](https://apps.autodesk.com/FUSION/en/Detail/Index?id=1259509007239787473appLang=enos=Mac)
   - [Nicebox Add-on](https://apps.autodesk.com/FUSION/en/Detail/Index?id=3012670521465945402appLang=enos=Mac)
   - [export to SVG](https://github.com/NicoSchlueter/ExportToSVG)
   - [FuseNest](https://apps.autodesk.com/FUSION/en/Detail/Index?id=3941129300784530623appLang=enos=Mac)
 
-
 <iframe width="700" height="400" src="https://www.youtube.com/embed/B5ocZrpvEzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-https://youtu.be/B5ocZrpvEzI
+<https://youtu.be/B5ocZrpvEzI>
 
-Notizen: 
+Notizen:
 
 - Skripte + ADD-INs selbst erstellen:
 
-- - [Nutzungshandbuch Guide: Creating a Script](https://help.autodesk.com/view/fusion360/ENU/?guid=GUID-9701BBA7-EC0E-4016-A9C8-964AA4838954)
+  - [Nutzungshandbuch Guide: Creating a Script](https://help.autodesk.com/view/fusion360/ENU/?guid=GUID-9701BBA7-EC0E-4016-A9C8-964AA4838954)
   - [Mehrteiliger Online-Kurs zum Erstellen von ADD-INs und Skripten](https://fusion360api.weebly.com/)
   - [Intro into the Fusion API](https://www.youtube.com/g0xWqLen7gI) - Präsentation auf Youtube  (Veraltet von 2015 aber die Grundprinzipien sind die selben)
 
-
-# Session 08: The Lost lecture  
+## Session 08: The Lost lecture  
 
 Everything else you can do in Fusion:
 
-CAM [(intro](https://tugz.ovgu.de/tugz_media/MakerLabs/Einstellungen/CNC_Portalfraese/Anleitung_CAM_Autodesk_Fusion_NTG-p-3520.pdf)[ PDF)](https://tugz.ovgu.de/tugz_media/MakerLabs/Einstellungen/CNC_Portalfraese/Anleitung_CAM_Autodesk_Fusion_NTG-p-3520.pdf)
+CAM [(intro](https://tugz.ovgu.de/tugz_media/MakerLabs/Einstellungen/CNC_Portalfraese/Anleitung_CAM_Autodesk_Fusion_NTG-p-3520.pdf)[PDF)](https://tugz.ovgu.de/tugz_media/MakerLabs/Einstellungen/CNC_Portalfraese/Anleitung_CAM_Autodesk_Fusion_NTG-p-3520.pdf)
 
-Simulations 
+Simulations
 
 Electronics
 
-Generative Design 
+Generative Design
 
-Addons 
+Addons
 
-Nesting 
+Nesting
 
 Grenzen von Fusion:
 
 Use the right tool for the Job!
 
-Animationen: 
+Animationen:
 
 - Blender
 
@@ -323,18 +311,17 @@ Rendering (advanced)
 
 Advanced Parametric design:
 
-- Dynamo (Windows only) 
+- Dynamo (Windows only)
 
-- Rhino+Grasshopper 
+- Rhino+Grasshopper
 
 ----------
 
-Falls ihr eure dateien nicht vewrschieben könnt schickt mir im burgchat eine nachricht mit dem Link 
+Falls ihr eure dateien nicht vewrschieben könnt schickt mir im burgchat eine nachricht mit dem Link
 
 Hilferessourcen für Fusion 360:
 
 [Offizielles Nutzungshandbuch](https://help.autodesk.com/view/NINVFUS/DEU/)
-
 
 <!-- Resources and scripts -->
 <html>

--- a/docs/CAD/fusion360course/CAD2-advanced.md
+++ b/docs/CAD/fusion360course/CAD2-advanced.md
@@ -9,6 +9,7 @@
 - [Session 06: 3D Formate und Zeichnungen](#session-06-3d-formate-und-zeichnungen)
 - [Session 07: Add-Ins/Scripts + Wiederholung Baugruppen](#session-07-add-insscripts--wiederholung-baugruppen)
 - [Session 08: The Lost lecture](#session-08-the-lost-lecture)
+
 -----
 
 ## Vorbereitung
@@ -70,7 +71,7 @@
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/NjqGgR21fpI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-#### Problemlösungen:
+#### Problemlösungen
 
 Wandstärke nicht einstellbar (Shell-Funktion am Ausguss): <https://youtu.be/JYpVVjVQE-g>
 
@@ -110,7 +111,6 @@ Link zum Bild: <https://a360.co/3dUx4VU>
 dieses Kurz-Tutorial durcharbeiten.
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/eRUv6s5Jgi8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 
  Notizen:
 
@@ -171,7 +171,6 @@ Link zur Solidworks Datei
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/w5eAMIv4M9A" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-
  Homework:
 
 Ladet euch auf einer Seite wie Grabcad ein 3D Modell mit mindestens 4 Körpern/Komponeneten herunter und erstellt eine mehrseitige technische Zeichung mit allen nötigen Maßen, einer Explosionsansicht der Einzelteile sowie einer Übersicht von Objekten aus gleichem Material (Schnittplan).
@@ -209,7 +208,6 @@ Link zum [**Autodesk Fusion 360 App Store**](https://apps.autodesk.com/FUSION/en
   - [FuseNest](https://apps.autodesk.com/FUSION/en/Detail/Index?id=3941129300784530623appLang=enos=Mac)
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/B5ocZrpvEzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 
 Notizen:
 
@@ -271,4 +269,3 @@ Hilferessourcen für Fusion 360:
 <link rel="stylesheet" href="https://unpkg.com/docsify-toc@1.0.0/dist/toc.css">
 <script src="https://unpkg.com/docsify-toc@1.0.0/dist/toc.js"></script>
 </html>
-

--- a/docs/CAD/fusion360course/CAD2-advanced.md
+++ b/docs/CAD/fusion360course/CAD2-advanced.md
@@ -1,15 +1,5 @@
 # CAD2 Fusion Kurs Advanced
 
-- [Vorbereitung](#vorbereitung)
-- [Session 1: Recap](#session-1-recap)
-- [Session 2: Create Geometry](#session-2-create-geometry)
-- [Session 3: Assembly Deep-Dive](#session-3-assembly-deep-dive)
-- [Session 04: Create Form (Sculpting Mode)](#session-04-create-form-sculpting-mode)
-- [Session 05: Parametrik und Blechbearbeitung](#session-05-parametrik-und-blechbearbeitung)
-- [Session 06: 3D Formate und Zeichnungen](#session-06-3d-formate-und-zeichnungen)
-- [Session 07: Add-Ins/Scripts + Wiederholung Baugruppen](#session-07-add-insscripts--wiederholung-baugruppen)
-- [Session 08: The Lost lecture](#session-08-the-lost-lecture)
-
 -----
 
 ## Vorbereitung

--- a/docs/CAD/fusion360course/CAD2-advanced.md
+++ b/docs/CAD/fusion360course/CAD2-advanced.md
@@ -1,0 +1,342 @@
+# CAD2 Fusion Kurs Advanced
+
+- [Vorbereitung](#vorbereitung)
+- [Session 1: Recap](#session-1-recap)
+- [Session 2: Create Geometry](#session-2-create-geometry)
+- [Session 3: Assembly Deep-Dive](#session-3-assembly-deep-dive)
+- [Session 04: Create Form (Sculpting Mode)](#session-04-create-form-sculpting-mode)
+- [Session 05: Parametrik und Blechbearbeitung](#session-05-parametrik-und-blechbearbeitung)
+- [Session 06: 3D Formate und Zeichnungen](#session-06-3d-formate-und-zeichnungen)
+- [Session 07: Add-Ins/Scripts + Wiederholung Baugruppen](#session-07-add-insscripts--wiederholung-baugruppen)
+- [Session 08: The Lost lecture](#session-08-the-lost-lecture)
+
+# Vorbereitung
+
+- [Fusion Installieren ](https://www.autodesk.com/education/edu-software/overview?sorting=featuredpage=1filters=individualsearch=FUSION)
+- Mails lesen 
+
+# Session 1: Recap
+
+**Lernziel:** Gesamtüberblick über Fusion (wieder-) bekommen. Bekannte Funktionen richtig nutzen. Begriffe kennenlernen. 
+
+
+<iframe width="700" height="400" src="https://www.youtube.com/embed/ikiBYJz1tbA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+https://youtu.be/ikiBYJz1tbA
+
+Topics: 
+
+**Skizzieren** 
+
+- - Bemaßungen 
+  - Constraints
+  - Projektion
+  - Mirror
+
+**Geometrie erzeugen** 
+
+- Extrude 
+  - Extrude Surface
+
+**Simple Joints**
+
+# Session 2: Create Geometry 
+
+![img](https://i.pinimg.com/564x/4b/bc/98/4bbc98fc32dcc1c33c8f23b39be47919.jpg)
+
+ Lernziele: 
+
+- Geometrieerstellung üben 
+- Best Practices einhalten 
+- Nach Referenz Modellieren 
+ Topics: 
+
+**Skizzieren** 
+
+- - Canvas als Referenz
+  - Plane along Path
+  - Plane at angle 
+  - Fillets 
+  - Project to surface
+  - Pattern
+
+**Create / Modify**
+
+- - Revolve / Loft / Sweep
+  - Mirror / Pattern
+  - Shell
+
+ Tutorial Session 02
+
+Wir treffen uns 13:45 wieder im Googlemeet
+
+
+<iframe width="700" height="400" src="https://www.youtube.com/embed/NjqGgR21fpI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+https://youtu.be/NjqGgR21fpI
+
+**Problemlösungen:** 
+
+Wandstärke nicht einstellbar (Shell-Funktion am Ausguss): https://youtu.be/JYpVVjVQE-g
+
+ Homework: 
+
+Tasse Modellieren nach Referenz : 
+
+Link zum Bild: https://a360.co/3dUx4VU
+
+# Session 3: Assembly Deep-Dive
+
+ Topics: 
+
+**Joints** 
+
+![img](https://i.pinimg.com/564x/18/99/ff/1899ff2dfc717c16a6489552af258c2a.jpg)
+
+- - as-built Joint
+  - Joints
+  - - Rotate
+    - Pin-Slot
+  - Design Approaches: 
+  - - Bottom-up 
+    - Top-Down
+
+**Sonstiges**
+
+- - [Paste vs Paste-New](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-9EDE876B-6A97-47E9-AB87-F27ADFFDCEE9)
+  - Delete vs Remove
+
+ Tutorial: 
+
+
+<iframe width="700" height="400" src="https://www.youtube.com/embed/em0-RvzwQXo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+https://youtu.be/em0-RvzwQXo
+
+ Homework: 
+
+dieses Kurz-Tutorial durcharbeiten.
+
+<iframe width="700" height="400" src="https://www.youtube.com/embed/eRUv6s5Jgi8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+https://youtu.be/eRUv6s5Jgi8
+
+ Notizen: 
+
+Hier findet ihr eine gute Übersicht über alle Joint Arten: [Video](https://www.youtube.com/Bw08O6XsfDIfeature=emb_titleab_channel=NYCCNC)
+
+# Session 04: Create Form (Sculpting Mode)
+
+ Tutorial Session 04:
+
+
+<iframe width="700" height="400" src="https://www.youtube.com/embed/bATAm1ZuLjk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://youtu.be/bATAm1ZuLjk
+
+https://www.pinterest.de/rowlllllll/organic-modelling/
+
+<div>
+<a data-pin-do="embedBoard" data-pin-board-width="700" data-pin-scale-height="400" data-pin-scale-width="60" href="https://www.pinterest.de/rowlllllll/organic-modelling/"></a>
+</div>
+Homework: 
+
+Modelliert ein Objekt nach Vorlage mit der “Create Form” - Funktion und Rendert es anschließend in Fusion. 
+
+Schaut euch Dazu noch dieses Tutorial an in dem ich euch ein paar Tipps gebe wie ihr in Fusion Rendern könnt. Ich zeige auch ein paar Funktionen die ihr noch 
+
+Kostenlose HDRIs (wird im Tutorial erklärt):
+
+- - **Maximeroz:** https://www.maximeroz.com/hdri-free-pack
+  - **HDRI-Haven:** https://hdrihaven.com/
+  - **viz- people:** https://www.viz-people.com/portfolio/free-hdri-maps/
+  - **openfootage:** https://www.openfootage.net/hdri-panorama/ (kostenlos in der niedrigen Auflösung)
+  - **Eisklotz.de**: https://www.eisklotz.com/products/hdri/
+
+
+<iframe width="700" height="400" src="https://www.youtube.com/embed/rhY-p0IJlw8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://youtu.be/rhY-p0IJlw8
+
+# Session 05: Parametrik und Blechbearbeitung
+
+**Inhalte:** 
+
+[Parametrik ](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-76272551-3275-46C4-AE4D-10D58B408C20)
+
+[Blechfunktion ](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-309ACAF1-59BC-4CF0-9D14-98BA5EDC2685)
+
+ Tutorial Session 05:
+
+
+<iframe width="700" height="400" src="https://www.youtube.com/embed/3j68V_jSpLM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://youtu.be/3j68V_jSpLM
+
+**Homework:** 
+
+- Tutorial fertig arbeiten
+
+# Session 06: 3D Formate und Zeichnungen
+
+ Übersicht 3D-Dateiformate
+
+**Proprietäre Formate** **(Softwaregebunden)**
+
+- [Rhino](https://www.rhino3d.com/) Files (*.3dm).
+- [Autodesk Inventor](https://www.autodesk.com/products/inventor/overview) Files (*.ipt, *.iam - up to Inventor 2019)
+- [SolidWorks](https://www.solidworks.com/) Files (*.prt, *.asm, *.sldprt, *.sldasm , **.slddrw)*
+- [Autodesk Alias](https://www.autodesk.com/products/alias-products/overview?plc=ALSCPTterm=1-YEARsupport=ADVANCEDquantity=1) (*.wire)
+- [123D](https://www.autodesk.com/solutions/123d-apps) File (*.123dx)
+- [AutoCAD](https://www.autodesk.com/products/autocad/overview?support=ADVANCED) DWG Files (*.dwg)
+- [SketchUp](https://www.sketchup.com/products/sketchup-pro) Files (*.skp)
+- [CATIA ](https://www.3ds.com/de/produkte-und-services/catia/)V5 Files (*.CATProduct, *.CATPart)
+- Autodesk Fusion 360 Archive Files (*.f3d)
+- [Siemens NX](https://www.plm.automation.siemens.com/global/en/products/nx/) (*prt)
+- [Parasolid](https://de.wikipedia.org/wiki/Parasolid) Files (*.x_b, *.x_t)
+- [Pro/ENGINEER and Creo Parametric](https://www.ptc.com/en/products/creo/whats-new) Files (*.asm, *.prt)
+- [Pro/ENGINEER Granite](https://www.ptc.com/de/~/media/DE/Files/PDFs/CAD/GRANITE_Interoperability_Kernel.ashx?la=en) Files (*.g)
+- [Pro/ENGINEER Neutral](http://support.ptc.com/help/creo/creo_pma/usascii/index.html#page/data_exchange/interface/About_Part_and_Assembly_Neutral_Files.html) Files(*.neu)
+- Autodesk Fusion 360 Toolpath Archive Files (*.cam360)
+- [Blender](https://www.blender.org/) File (.blend)
+
+[Super Nützlicher CAD Conversion Finder ](https://www.cadforum.cz/cadforum_en/formats.asp)
+
+[Noch Mehr CAD und 3D-Programme](https://en.wikipedia.org/wiki/Comparison_of_computer-aided_design_software)
+**Interchange Formate** **(unabhängig** **von Software):**
+
+| Format                                                       | Ending                  | Type                                                         | Additional Data                                              | Used in | Notes                                 |
+| ------------------------------------------------------------ | ----------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------- | ------------------------------------- |
+| [STEP](https://en.wikipedia.org/wiki/ISO_10303)              | .stp / .step            | [BREP](https://en.wikipedia.org/wiki/Boundary_representation)Surfaces | Different additional  data according to [Standards](https://en.wikipedia.org/wiki/ISO_10303#Coverage_of_STEP_Application_Protocols_(AP)) |         | Most standard file format             |
+| [IGES](https://en.wikipedia.org/wiki/IGES)                   | .igs / .iges            | BREPSurfaces                                                 | [circuit diagrams](https://en.wikipedia.org/wiki/Circuit_diagram), [wireframe](https://en.wikipedia.org/wiki/Wire_frame_model), [freeform surface](https://en.wikipedia.org/wiki/Freeform_surface_modelling) or [solid modeling](https://en.wikipedia.org/wiki/Solid_modeling) [representations](https://en.wikipedia.org/wiki/Representation_(arts)) |         | Not updated since 1994                |
+| [Wavefront OBJ](https://en.wikipedia.org/wiki/Wavefront_.obj_file) | .obj                    | Both Mesh and Nurbs                                          | Texture                                                      |         |                                       |
+| [AMF](https://en.wikipedia.org/wiki/Additive_manufacturing_file_format) | .amf                    | Mesh                                                         | color, materials, lattices, and constellations               |         |                                       |
+| [Collada](https://en.wikipedia.org/wiki/COLLADA)             | .dae                    | Mesh                                                         | Colors, Textures, Collaborative, Physics, Animations         |         |                                       |
+| [3MF](https://en.wikipedia.org/wiki/3D_Manufacturing_Format) | .3mf                    | Mesh                                                         | Full color and texture support in a single fileSupport structures attached to part dataFull tray support for direct machine preparationEfficient storage of beam latticesMultiple material supportNative integration in Microsoft Office and [Paint 3D](https://en.wikipedia.org/wiki/Paint_3D) |         | Designed for industrial manufacturing |
+| [STL - Stereolithography](https://en.wikipedia.org/wiki/STL_(file_format)) | .stl                    | Mesh                                                         | No additional information                                    |         |                                       |
+| [Polygon File Format](https://en.wikipedia.org/wiki/PLY_(file_format)) (Pointcloud) | .ply                    | Mesh                                                         | color and transparency, surface normals, texture coordinates and data confidence values |         |                                       |
+| [VRML-](https://en.wikipedia.org/wiki/VRML)[Virtual Reality Modeling Language](https://en.wikipedia.org/wiki/VRML) | .wrl.wrz                | Mesh                                                         |                                                              |         |                                       |
+| [X3D ](https://en.wikipedia.org/wiki/X3D)                    | .x3d.x3dv, .x3db, .x3dz |                                                              | [Geospatial](https://en.wikipedia.org/wiki/Geospatial)AnimationNURBS |         |                                       |
+| [ACIS - SAT/SMT](https://en.wikipedia.org/wiki/ACIS)         | .sat                    | [BREP](https://en.wikipedia.org/wiki/Boundary_representation)Surfaces | integrates [wireframe model](https://en.wikipedia.org/wiki/Wireframe_model), [surface](https://en.wikipedia.org/wiki/Surface_(topology)), and [solid modeling](https://en.wikipedia.org/wiki/Solid_modeling) functionality with both [manifold and non-manifold topology](https://en.wikipedia.org/wiki/List_of_manifolds), and a rich set of geometric operations. |         |                                       |
+| [DXF](https://en.wikipedia.org/wiki/AutoCAD_DXF)[(Drawing Exchange Format)](https://en.wikipedia.org/wiki/AutoCAD_DXF) | .dxf                    | 2D Paths                                                     |                                                              |         |                                       |
+
+Alle Dateiformate die Fusion einlesen und umwandeln kann:
+
+https://knowledge.autodesk.com/support/fusion-360/troubleshooting/caas/sfdcarticles/sfdcarticles/File-formats-supported-by-Fusion-360.html
+
+**Leitfaden Dateiexport:** 
+
+Immer die Ursprungsdatei mit exportieren um keine Informationen zu verlieren. 
+
+Nach Möglichkeit und Verwendungsyweck verschiedene Interchange-Formate mitliefern.
+
+ Tutorial
+
+Link zur Solidworks Datei
+
+https://www.dropbox.com/sh/usd62jexewc6ggp/AACkJ-t9Tnk_LFQl1eQxe7Uda?dl=0
+
+
+<iframe width="700" height="400" src="https://www.youtube.com/embed/w5eAMIv4M9A" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://youtu.be/w5eAMIv4M9A
+
+ Homework:
+
+Ladet euch auf einer Seite wie Grabcad ein 3D Modell mit mindestens 4 Körpern/Komponeneten herunter und erstellt eine mehrseitige technische Zeichung mit allen nötigen Maßen, einer Explosionsansicht der Einzelteile sowie einer Übersicht von Objekten aus gleichem Material (Schnittplan). 
+
+Webseiten zum Download von 3D-Modellen:
+
+- [https://grabcad.com/](https://grabcad.com/library)
+- https://gallery.autodesk.com/
+- https://b2b.partcommunity.com/community/
+- https://www.traceparts.com/en
+- https://www.3dcontentcentral.com/
+- https://www.turbosquid.com/Search/3D-Models/free/cad
+
+# Session 07: Add-Ins/Scripts + Wiederholung Baugruppen
+
+ **Topics:**
+
+- [Autodesk Fusion 360 App Store](https://apps.autodesk.com/FUSION/en/Home/Index)  ([Nutzungshinweise](https://apps.autodesk.com/en/Public/FAQ)[ und FAQ](https://apps.autodesk.com/en/Public/FAQ))
+- Unterschied: Script vs ADD-IN
+- ADD-INs in Fusion aktivieren
+- Zahnräder erstellen mit dem [HG+](https://apps.autodesk.com/FUSION/en/Detail/Index?id=1259509007239787473appLang=enos=Mac) ADD-In
+- Joints Platzieren
+  - Unterschied: [**Joint**](https://help.autodesk.com/view/fusion360/ENU/?guid=ASM-JOINT-COMMAND) vs [**As-Built-Joint**](https://help.autodesk.com/view/fusion360/ENU/?guid=ASM-AS-BUILT-JOINT-COMMAND)   (DE: [**Gelenk**](https://help.autodesk.com/view/NINVFUS/DEU/?guid=ASM-JOINT-COMMAND) vs [**Verbinden wie Modelliert**](https://help.autodesk.com/view/NINVFUS/DEU/?guid=ASM-AS-BUILT-JOINT-COMMAND)**)**
+  - Motion Links setzen und definieren 
+
+ Tutorial Session 07:
+
+Link zum [**Autodesk Fusion 360 App Store**](https://apps.autodesk.com/FUSION/en/Home/Index) 
+
+- **Erwähnte Add-Ins** **(Apps):**
+
+- - [Helical Gear Pkus](https://apps.autodesk.com/FUSION/en/Detail/Index?id=1259509007239787473appLang=enos=Mac)
+  - [Nicebox Add-on](https://apps.autodesk.com/FUSION/en/Detail/Index?id=3012670521465945402appLang=enos=Mac)
+  - [export to SVG](https://github.com/NicoSchlueter/ExportToSVG)
+  - [FuseNest](https://apps.autodesk.com/FUSION/en/Detail/Index?id=3941129300784530623appLang=enos=Mac)
+
+
+<iframe width="700" height="400" src="https://www.youtube.com/embed/B5ocZrpvEzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://youtu.be/B5ocZrpvEzI
+
+Notizen: 
+
+- Skripte + ADD-INs selbst erstellen:
+
+- - [Nutzungshandbuch Guide: Creating a Script](https://help.autodesk.com/view/fusion360/ENU/?guid=GUID-9701BBA7-EC0E-4016-A9C8-964AA4838954)
+  - [Mehrteiliger Online-Kurs zum Erstellen von ADD-INs und Skripten](https://fusion360api.weebly.com/)
+  - [Intro into the Fusion API](https://www.youtube.com/g0xWqLen7gI) - Präsentation auf Youtube  (Veraltet von 2015 aber die Grundprinzipien sind die selben)
+
+
+# Session 08: The Lost lecture  
+
+Everything else you can do in Fusion:
+
+CAM [(intro](https://tugz.ovgu.de/tugz_media/MakerLabs/Einstellungen/CNC_Portalfraese/Anleitung_CAM_Autodesk_Fusion_NTG-p-3520.pdf)[ PDF)](https://tugz.ovgu.de/tugz_media/MakerLabs/Einstellungen/CNC_Portalfraese/Anleitung_CAM_Autodesk_Fusion_NTG-p-3520.pdf)
+
+Simulations 
+
+Electronics
+
+Generative Design 
+
+Addons 
+
+Nesting 
+
+Grenzen von Fusion:
+
+Use the right tool for the Job!
+
+Animationen: 
+
+- Blender
+
+- Makehuman
+
+Rendering (advanced)
+
+- Keyshot
+
+- Autodesk Vray
+
+Advanced Parametric design:
+
+- Dynamo (Windows only) 
+
+- Rhino+Grasshopper 
+
+----------
+
+Falls ihr eure dateien nicht vewrschieben könnt schickt mir im burgchat eine nachricht mit dem Link 
+
+Hilferessourcen für Fusion 360:
+
+[Offizielles Nutzungshandbuch](https://help.autodesk.com/view/NINVFUS/DEU/)
+
+
+<!-- Resources and scripts -->
+<html>
+<script async defer src="//assets.pinterest.com/js/pinit.js"></script>
+</html>

--- a/docs/CAD/fusion360course/CAD2-advanced.md
+++ b/docs/CAD/fusion360course/CAD2-advanced.md
@@ -172,56 +172,7 @@ Kostenlose HDRIs (wird im Tutorial erklärt):
 
 ## Session 06: 3D Formate und Zeichnungen
 
- Übersicht 3D-Dateiformate
-
-**Proprietäre Formate** **(Softwaregebunden)**
-
-- [Rhino](https://www.rhino3d.com/) Files (*.3dm).
-- [Autodesk Inventor](https://www.autodesk.com/products/inventor/overview) Files (*.ipt,*.iam - up to Inventor 2019)
-- [SolidWorks](https://www.solidworks.com/) Files (*.prt,*.asm, *.sldprt,*.sldasm , **.slddrw)*
-- [Autodesk Alias](https://www.autodesk.com/products/alias-products/overview?plc=ALSCPTterm=1-YEARsupport=ADVANCEDquantity=1) (*.wire)
-- [123D](https://www.autodesk.com/solutions/123d-apps) File (*.123dx)
-- [AutoCAD](https://www.autodesk.com/products/autocad/overview?support=ADVANCED) DWG Files (*.dwg)
-- [SketchUp](https://www.sketchup.com/products/sketchup-pro) Files (*.skp)
-- [CATIA](https://www.3ds.com/de/produkte-und-services/catia/)V5 Files (*.CATProduct,*.CATPart)
-- Autodesk Fusion 360 Archive Files (*.f3d)
-- [Siemens NX](https://www.plm.automation.siemens.com/global/en/products/nx/) (*prt)
-- [Parasolid](https://de.wikipedia.org/wiki/Parasolid) Files (*.x_b,*.x_t)
-- [Pro/ENGINEER and Creo Parametric](https://www.ptc.com/en/products/creo/whats-new) Files (*.asm,*.prt)
-- [Pro/ENGINEER Granite](https://www.ptc.com/de/~/media/DE/Files/PDFs/CAD/GRANITE_Interoperability_Kernel.ashx?la=en) Files (*.g)
-- [Pro/ENGINEER Neutral](http://support.ptc.com/help/creo/creo_pma/usascii/index.html#page/data_exchange/interface/About_Part_and_Assembly_Neutral_Files.html) Files(*.neu)
-- Autodesk Fusion 360 Toolpath Archive Files (*.cam360)
-- [Blender](https://www.blender.org/) File (.blend)
-
-[Super Nützlicher CAD Conversion Finder](https://www.cadforum.cz/cadforum_en/formats.asp)
-
-[Noch Mehr CAD und 3D-Programme](https://en.wikipedia.org/wiki/Comparison_of_computer-aided_design_software)
-**Interchange Formate** **(unabhängig** **von Software):**
-
-| Format                                                       | Ending                  | Type                                                         | Additional Data                                              | Used in | Notes                                 |
-| ------------------------------------------------------------ | ----------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------- | ------------------------------------- |
-| [STEP](https://en.wikipedia.org/wiki/ISO_10303)              | .stp / .step            | [BREP](https://en.wikipedia.org/wiki/Boundary_representation)Surfaces | Different additional  data according to [Standards](https://en.wikipedia.org/wiki/ISO_10303#Coverage_of_STEP_Application_Protocols_(AP)) |         | Most standard file format             |
-| [IGES](https://en.wikipedia.org/wiki/IGES)                   | .igs / .iges            | BREPSurfaces                                                 | [circuit diagrams](https://en.wikipedia.org/wiki/Circuit_diagram), [wireframe](https://en.wikipedia.org/wiki/Wire_frame_model), [freeform surface](https://en.wikipedia.org/wiki/Freeform_surface_modelling) or [solid modeling](https://en.wikipedia.org/wiki/Solid_modeling) [representations](https://en.wikipedia.org/wiki/Representation_(arts)) |         | Not updated since 1994                |
-| [Wavefront OBJ](https://en.wikipedia.org/wiki/Wavefront_.obj_file) | .obj                    | Both Mesh and Nurbs                                          | Texture                                                      |         |                                       |
-| [AMF](https://en.wikipedia.org/wiki/Additive_manufacturing_file_format) | .amf                    | Mesh                                                         | color, materials, lattices, and constellations               |         |                                       |
-| [Collada](https://en.wikipedia.org/wiki/COLLADA)             | .dae                    | Mesh                                                         | Colors, Textures, Collaborative, Physics, Animations         |         |                                       |
-| [3MF](https://en.wikipedia.org/wiki/3D_Manufacturing_Format) | .3mf                    | Mesh                                                         | Full color and texture support in a single fileSupport structures attached to part dataFull tray support for direct machine preparationEfficient storage of beam latticesMultiple material supportNative integration in Microsoft Office and [Paint 3D](https://en.wikipedia.org/wiki/Paint_3D) |         | Designed for industrial manufacturing |
-| [STL - Stereolithography](https://en.wikipedia.org/wiki/STL_(file_format)) | .stl                    | Mesh                                                         | No additional information                                    |         |                                       |
-| [Polygon File Format](https://en.wikipedia.org/wiki/PLY_(file_format)) (Pointcloud) | .ply                    | Mesh                                                         | color and transparency, surface normals, texture coordinates and data confidence values |         |                                       |
-| [VRML-](https://en.wikipedia.org/wiki/VRML)[Virtual Reality Modeling Language](https://en.wikipedia.org/wiki/VRML) | .wrl.wrz                | Mesh                                                         |                                                              |         |                                       |
-| [X3D](https://en.wikipedia.org/wiki/X3D)                    | .x3d.x3dv, .x3db, .x3dz |                                                              | [Geospatial](https://en.wikipedia.org/wiki/Geospatial)AnimationNURBS |         |                                       |
-| [ACIS - SAT/SMT](https://en.wikipedia.org/wiki/ACIS)         | .sat                    | [BREP](https://en.wikipedia.org/wiki/Boundary_representation)Surfaces | integrates [wireframe model](https://en.wikipedia.org/wiki/Wireframe_model), [surface](https://en.wikipedia.org/wiki/Surface_(topology)), and [solid modeling](https://en.wikipedia.org/wiki/Solid_modeling) functionality with both [manifold and non-manifold topology](https://en.wikipedia.org/wiki/List_of_manifolds), and a rich set of geometric operations. |         |                                       |
-| [DXF](https://en.wikipedia.org/wiki/AutoCAD_DXF)[(Drawing Exchange Format)](https://en.wikipedia.org/wiki/AutoCAD_DXF) | .dxf                    | 2D Paths                                                     |                                                              |         |                                       |
-
-Alle Dateiformate die Fusion einlesen und umwandeln kann:
-
-<https://knowledge.autodesk.com/support/fusion-360/troubleshooting/caas/sfdcarticles/sfdcarticles/File-formats-supported-by-Fusion-360.html>
-
-**Leitfaden Dateiexport:**
-
-Immer die Ursprungsdatei mit exportieren um keine Informationen zu verlieren.
-
-Nach Möglichkeit und Verwendungsyweck verschiedene Interchange-Formate mitliefern.
+[3DFormat-Table](./Tabelle_3DFormate.md ':include')
 
  Tutorial
 
@@ -243,7 +194,7 @@ Webseiten zum Download von 3D-Modellen:
 - <https://gallery.autodesk.com/>
 - <https://b2b.partcommunity.com/community/>
 - <https://www.traceparts.com/en>
-- <https://www.3dcontentcentral.com/>
+- <https://www.3dcontentcentral.com/> <!-- markdown-link-check-disable-line -->
 - <https://www.turbosquid.com/Search/3D-Models/free/cad>
 
 ## Session 07: Add-Ins/Scripts + Wiederholung Baugruppen

--- a/docs/CAD/fusion360course/CAD2-advanced.md
+++ b/docs/CAD/fusion360course/CAD2-advanced.md
@@ -10,10 +10,14 @@
 - [Session 07: Add-Ins/Scripts + Wiederholung Baugruppen](#session-07-add-insscripts--wiederholung-baugruppen)
 - [Session 08: The Lost lecture](#session-08-the-lost-lecture)
 
+-----
+<!-- markdownlint-disable no-emphasis-as-header -->
 ## Vorbereitung
 
 - [Fusion Installieren](https://www.autodesk.com/education/edu-software/overview?sorting=featuredpage=1filters=individualsearch=FUSION)
 - Mails lesen
+
+-----
 
 ## Session 1: Recap
 
@@ -42,7 +46,7 @@ Topics:
 
 ![img](https://i.pinimg.com/564x/4b/bc/98/4bbc98fc32dcc1c33c8f23b39be47919.jpg)
 
- Lernziele:
+### Lernziele
 
 - Geometrieerstellung üben
 - Best Practices einhalten
@@ -81,24 +85,24 @@ Link zum Bild: <https://a360.co/3dUx4VU>
 
 ## Session 3: Assembly Deep-Dive
 
- Topics:
+### Topics
 
 **Joints**
 
 ![img](https://i.pinimg.com/564x/18/99/ff/1899ff2dfc717c16a6489552af258c2a.jpg)
 
-  - as-built Joint
-  - Joints
-    -  Rotate
-    - Pin-Slot
-  - Design Approaches:
-    - Bottom-up
-    - Top-Down
+- as-built Joint
+- Joints
+  - Rotate
+  - Pin-Slot
+- Design Approaches:
+  - Bottom-up
+  - Top-Down
 
 **Sonstiges**
 
-  - [Paste vs Paste-New](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-9EDE876B-6A97-47E9-AB87-F27ADFFDCEE9)
-  - Delete vs Remove
+- [Paste vs Paste-New](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-9EDE876B-6A97-47E9-AB87-F27ADFFDCEE9)
+- Delete vs Remove
 
  Tutorial:
 
@@ -119,7 +123,7 @@ Hier findet ihr eine gute Übersicht über alle Joint Arten: [Video](https://www
 
 ## Session 04: Create Form (Sculpting Mode)
 
- Tutorial Session 04:
+Tutorial Session 04:
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/bATAm1ZuLjk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -315,7 +319,7 @@ Advanced Parametric design:
 
 - Rhino+Grasshopper
 
-----------
+-----
 
 Falls ihr eure dateien nicht vewrschieben könnt schickt mir im burgchat eine nachricht mit dem Link
 
@@ -323,6 +327,7 @@ Hilferessourcen für Fusion 360:
 
 [Offizielles Nutzungshandbuch](https://help.autodesk.com/view/NINVFUS/DEU/)
 
+<!-- markdownlint-enable no-emphasis-as-header -->
 <!-- Resources and scripts -->
 <html>
 <script async defer src="//assets.pinterest.com/js/pinit.js"></script>

--- a/docs/CAD/fusion360course/CAD2-advanced.md
+++ b/docs/CAD/fusion360course/CAD2-advanced.md
@@ -1,5 +1,15 @@
 # CAD2 Fusion Kurs Advanced
 
+- [Vorbereitung](#vorbereitung)
+- [Session 1: Recap](#session-1-recap)
+- [Session 2: Create Geometry](#session-2-create-geometry)
+- [Session 3: Assembly Deep-Dive](#session-3-assembly-deep-dive)
+- [Session 04: Create Form (Sculpting Mode)](#session-04-create-form-sculpting-mode)
+- [Session 05: Parametrik und Blechbearbeitung](#session-05-parametrik-und-blechbearbeitung)
+- [Session 06: 3D Formate und Zeichnungen](#session-06-3d-formate-und-zeichnungen)
+- [Session 07: Add-Ins/Scripts + Wiederholung Baugruppen](#session-07-add-insscripts--wiederholung-baugruppen)
+- [Session 08: The Lost lecture](#session-08-the-lost-lecture)
+
 -----
 
 ## Vorbereitung

--- a/docs/CAD/fusion360course/CAD2-advanced.md
+++ b/docs/CAD/fusion360course/CAD2-advanced.md
@@ -9,9 +9,8 @@
 - [Session 06: 3D Formate und Zeichnungen](#session-06-3d-formate-und-zeichnungen)
 - [Session 07: Add-Ins/Scripts + Wiederholung Baugruppen](#session-07-add-insscripts--wiederholung-baugruppen)
 - [Session 08: The Lost lecture](#session-08-the-lost-lecture)
-
 -----
-<!-- markdownlint-disable no-emphasis-as-header -->
+
 ## Vorbereitung
 
 - [Fusion Installieren](https://www.autodesk.com/education/edu-software/overview?sorting=featuredpage=1filters=individualsearch=FUSION)
@@ -24,23 +23,22 @@
 **Lernziel:** Gesamtüberblick über Fusion (wieder-) bekommen. Bekannte Funktionen richtig nutzen. Begriffe kennenlernen.
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/ikiBYJz1tbA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-https://youtu.be/ikiBYJz1tbA
 
-Topics:
+### Topics
 
-**Skizzieren**
+#### Skizzieren
 
 - Bemaßungen
 - Constraints
 - Projektion
 - Mirror
 
-**Geometrie erzeugen**
+#### Geometrie erzeugen
 
 - Extrude
   - Extrude Surface
 
-**Simple Joints**
+#### Simple Joints
 
 ## Session 2: Create Geometry
 
@@ -53,7 +51,7 @@ Topics:
 - Nach Referenz Modellieren
  Topics:
 
-**Skizzieren**
+#### Skizzieren
 
 - Canvas als Referenz
 - Plane along Path
@@ -62,7 +60,7 @@ Topics:
 - Project to surface
 - Pattern
 
-**Create / Modify**
+#### Create / Modify
 
 - Revolve / Loft / Sweep
 - Mirror / Pattern
@@ -71,9 +69,8 @@ Topics:
  Tutorial Session 02
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/NjqGgR21fpI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-https://youtu.be/NjqGgR21fpI
 
-**Problemlösungen:**
+#### Problemlösungen:
 
 Wandstärke nicht einstellbar (Shell-Funktion am Ausguss): <https://youtu.be/JYpVVjVQE-g>
 
@@ -87,7 +84,7 @@ Link zum Bild: <https://a360.co/3dUx4VU>
 
 ### Topics
 
-**Joints**
+#### Joints
 
 ![img](https://i.pinimg.com/564x/18/99/ff/1899ff2dfc717c16a6489552af258c2a.jpg)
 
@@ -99,7 +96,7 @@ Link zum Bild: <https://a360.co/3dUx4VU>
   - Bottom-up
   - Top-Down
 
-**Sonstiges**
+#### Sonstiges
 
 - [Paste vs Paste-New](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-9EDE876B-6A97-47E9-AB87-F27ADFFDCEE9)
 - Delete vs Remove
@@ -107,7 +104,6 @@ Link zum Bild: <https://a360.co/3dUx4VU>
  Tutorial:
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/em0-RvzwQXo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-https://youtu.be/em0-RvzwQXo
 
  Homework:
 
@@ -115,7 +111,6 @@ dieses Kurz-Tutorial durcharbeiten.
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/eRUv6s5Jgi8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtu.be/eRUv6s5Jgi8>
 
  Notizen:
 
@@ -126,8 +121,6 @@ Hier findet ihr eine gute Übersicht über alle Joint Arten: [Video](https://www
 Tutorial Session 04:
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/bATAm1ZuLjk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-<https://youtu.be/bATAm1ZuLjk>
 
 <https://www.pinterest.de/rowlllllll/organic-modelling/>
 
@@ -150,11 +143,9 @@ Kostenlose HDRIs (wird im Tutorial erklärt):
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/rhY-p0IJlw8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtu.be/rhY-p0IJlw8>
-
 ## Session 05: Parametrik und Blechbearbeitung
 
-**Inhalte:**
+### Inhalte
 
 [Parametrik](https://help.autodesk.com/view/NINVFUS/DEU/?guid=GUID-76272551-3275-46C4-AE4D-10D58B408C20)
 
@@ -164,9 +155,7 @@ Kostenlose HDRIs (wird im Tutorial erklärt):
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/3j68V_jSpLM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtu.be/3j68V_jSpLM>
-
-**Homework:**
+#### Homework
 
 - Tutorial fertig arbeiten
 
@@ -182,7 +171,6 @@ Link zur Solidworks Datei
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/w5eAMIv4M9A" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtu.be/w5eAMIv4M9A>
 
  Homework:
 
@@ -199,7 +187,7 @@ Webseiten zum Download von 3D-Modellen:
 
 ## Session 07: Add-Ins/Scripts + Wiederholung Baugruppen
 
- **Topics:**
+### Topics
 
 - [Autodesk Fusion 360 App Store](https://apps.autodesk.com/FUSION/en/Home/Index)  ([Nutzungshinweise](https://apps.autodesk.com/en/Public/FAQ)[und FAQ](https://apps.autodesk.com/en/Public/FAQ))
 - Unterschied: Script vs ADD-IN
@@ -222,7 +210,6 @@ Link zum [**Autodesk Fusion 360 App Store**](https://apps.autodesk.com/FUSION/en
 
 <iframe width="700" height="400" src="https://www.youtube.com/embed/B5ocZrpvEzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<https://youtu.be/B5ocZrpvEzI>
 
 Notizen:
 
@@ -278,8 +265,10 @@ Hilferessourcen für Fusion 360:
 
 [Offizielles Nutzungshandbuch](https://help.autodesk.com/view/NINVFUS/DEU/)
 
-<!-- markdownlint-enable no-emphasis-as-header -->
 <!-- Resources and scripts -->
 <html>
 <script async defer src="//assets.pinterest.com/js/pinit.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/docsify-toc@1.0.0/dist/toc.css">
+<script src="https://unpkg.com/docsify-toc@1.0.0/dist/toc.js"></script>
 </html>
+

--- a/docs/CAD/fusion360course/CAD2-advanced.md
+++ b/docs/CAD/fusion360course/CAD2-advanced.md
@@ -119,7 +119,7 @@ dieses Kurz-Tutorial durcharbeiten.
 
  Notizen:
 
-Hier findet ihr eine gute Übersicht über alle Joint Arten: [Video](https://www.youtube.com/Bw08O6XsfDIfeature=emb_titleab_channel=NYCCNC)
+Hier findet ihr eine gute Übersicht über alle Joint Arten: [Video](https://www.youtube.com/watch/Bw08O6XsfDIfeature=emb_titleab_channel=NYCCNC)
 
 ## Session 04: Create Form (Sculpting Mode)
 
@@ -279,7 +279,7 @@ Notizen:
 
   - [Nutzungshandbuch Guide: Creating a Script](https://help.autodesk.com/view/fusion360/ENU/?guid=GUID-9701BBA7-EC0E-4016-A9C8-964AA4838954)
   - [Mehrteiliger Online-Kurs zum Erstellen von ADD-INs und Skripten](https://fusion360api.weebly.com/)
-  - [Intro into the Fusion API](https://www.youtube.com/g0xWqLen7gI) - Präsentation auf Youtube  (Veraltet von 2015 aber die Grundprinzipien sind die selben)
+  - [Intro into the Fusion API](https://www.youtube.com/watch/g0xWqLen7gI) - Präsentation auf Youtube  (Veraltet von 2015 aber die Grundprinzipien sind die selben)
 
 ## Session 08: The Lost lecture  
 

--- a/docs/CAD/fusion360course/Tabelle_3DFormate.md
+++ b/docs/CAD/fusion360course/Tabelle_3DFormate.md
@@ -1,0 +1,51 @@
+
+ ### Übersicht 3D-Dateiformate
+
+**Proprietäre Formate** **(Softwaregebunden)**
+
+- [Rhino](https://www.rhino3d.com/) Files (*.3dm).
+- [Autodesk Inventor](https://www.autodesk.com/products/inventor/overview) Files (*.ipt,*.iam - up to Inventor 2019)
+- [SolidWorks](https://www.solidworks.com/) Files (*.prt,*.asm, *.sldprt,*.sldasm , **.slddrw)* <!-- markdown-link-check-disable-line -->
+- [Autodesk Alias](https://www.autodesk.com/products/alias-products/overview?plc=ALSCPTterm=1-YEARsupport=ADVANCEDquantity=1) (*.wire)
+- [123D](https://www.autodesk.com/solutions/123d-apps) File (*.123dx)
+- [AutoCAD](https://www.autodesk.com/products/autocad/overview?support=ADVANCED) DWG Files (*.dwg)
+- [SketchUp](https://www.sketchup.com/products/sketchup-pro) Files (*.skp)
+- [CATIA](https://www.3ds.com/de/produkte-und-services/catia/)V5 Files (*.CATProduct,*.CATPart)
+- Autodesk Fusion 360 Archive Files (*.f3d)
+- [Siemens NX](https://www.plm.automation.siemens.com/global/en/products/nx/) (*prt)
+- [Parasolid](https://de.wikipedia.org/wiki/Parasolid) Files (*.x_b,*.x_t)
+- [Pro/ENGINEER and Creo Parametric](https://www.ptc.com/en/products/creo/whats-new) Files (*.asm,*.prt)
+- [Pro/ENGINEER Granite](https://www.ptc.com/de/~/media/DE/Files/PDFs/CAD/GRANITE_Interoperability_Kernel.ashx?la=en) Files (*.g)
+- [Pro/ENGINEER Neutral](http://support.ptc.com/help/creo/creo_pma/usascii/index.html#page/data_exchange/interface/About_Part_and_Assembly_Neutral_Files.html) Files(*.neu)
+- Autodesk Fusion 360 Toolpath Archive Files (*.cam360)
+- [Blender](https://www.blender.org/) File (.blend)
+
+[Super Nützlicher CAD Conversion Finder](https://www.cadforum.cz/cadforum_en/formats.asp)
+
+[Noch Mehr CAD und 3D-Programme](https://en.wikipedia.org/wiki/Comparison_of_computer-aided_design_software)
+**Interchange Formate** **(unabhängig** **von Software):**
+
+| Format                                                       | Ending                  | Type                                                         | Additional Data                                              | Used in | Notes                                 |
+| ------------------------------------------------------------ | ----------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------- | ------------------------------------- |
+| [STEP](https://en.wikipedia.org/wiki/ISO_10303)              | .stp / .step            | [BREP](https://en.wikipedia.org/wiki/Boundary_representation)Surfaces | Different additional  data according to [Standards](https://en.wikipedia.org/wiki/ISO_10303#Coverage_of_STEP_Application_Protocols_(AP)) |         | Most standard file format             |
+| [IGES](https://en.wikipedia.org/wiki/IGES)                   | .igs / .iges            | BREPSurfaces                                                 | [circuit diagrams](https://en.wikipedia.org/wiki/Circuit_diagram), [wireframe](https://en.wikipedia.org/wiki/Wire_frame_model), [freeform surface](https://en.wikipedia.org/wiki/Freeform_surface_modelling) or [solid modeling](https://en.wikipedia.org/wiki/Solid_modeling) [representations](https://en.wikipedia.org/wiki/Representation_(arts)) |         | Not updated since 1994                |
+| [Wavefront OBJ](https://en.wikipedia.org/wiki/Wavefront_.obj_file) | .obj                    | Both Mesh and Nurbs                                          | Texture                                                      |         |                                       |
+| [AMF](https://en.wikipedia.org/wiki/Additive_manufacturing_file_format) | .amf                    | Mesh                                                         | color, materials, lattices, and constellations               |         |                                       |
+| [Collada](https://en.wikipedia.org/wiki/COLLADA)             | .dae                    | Mesh                                                         | Colors, Textures, Collaborative, Physics, Animations         |         |                                       |
+| [3MF](https://en.wikipedia.org/wiki/3D_Manufacturing_Format) | .3mf                    | Mesh                                                         | Full color and texture support in a single fileSupport structures attached to part dataFull tray support for direct machine preparationEfficient storage of beam latticesMultiple material supportNative integration in Microsoft Office and [Paint 3D](https://en.wikipedia.org/wiki/Paint_3D) |         | Designed for industrial manufacturing |
+| [STL - Stereolithography](https://en.wikipedia.org/wiki/STL_(file_format)) | .stl                    | Mesh                                                         | No additional information                                    |         |                                       |
+| [Polygon File Format](https://en.wikipedia.org/wiki/PLY_(file_format)) (Pointcloud) | .ply                    | Mesh                                                         | color and transparency, surface normals, texture coordinates and data confidence values |         |                                       |
+| [VRML-](https://en.wikipedia.org/wiki/VRML)[Virtual Reality Modeling Language](https://en.wikipedia.org/wiki/VRML) | .wrl.wrz                | Mesh                                                         |                                                              |         |                                       |
+| [X3D](https://en.wikipedia.org/wiki/X3D)                    | .x3d.x3dv, .x3db, .x3dz |                                                              | [Geospatial](https://en.wikipedia.org/wiki/Geospatial)AnimationNURBS |         |                                       |
+| [ACIS - SAT/SMT](https://en.wikipedia.org/wiki/ACIS)         | .sat                    | [BREP](https://en.wikipedia.org/wiki/Boundary_representation)Surfaces | integrates [wireframe model](https://en.wikipedia.org/wiki/Wireframe_model), [surface](https://en.wikipedia.org/wiki/Surface_(topology)), and [solid modeling](https://en.wikipedia.org/wiki/Solid_modeling) functionality with both [manifold and non-manifold topology](https://en.wikipedia.org/wiki/List_of_manifolds), and a rich set of geometric operations. |         |                                       |
+| [DXF](https://en.wikipedia.org/wiki/AutoCAD_DXF)[(Drawing Exchange Format)](https://en.wikipedia.org/wiki/AutoCAD_DXF) | .dxf                    | 2D Paths                                                     |                                                              |         |                                       |
+
+Alle Dateiformate die Fusion einlesen und umwandeln kann:
+
+<https://knowledge.autodesk.com/support/fusion-360/troubleshooting/caas/sfdcarticles/sfdcarticles/File-formats-supported-by-Fusion-360.html>
+
+**Leitfaden Dateiexport:**
+
+Immer die Ursprungsdatei mit exportieren um keine Informationen zu verlieren.
+
+Nach Möglichkeit und Verwendungsyweck verschiedene Interchange-Formate mitliefern.

--- a/docs/CAD/fusion360course/Tabelle_3DFormate.md
+++ b/docs/CAD/fusion360course/Tabelle_3DFormate.md
@@ -1,5 +1,6 @@
 
- ### Übersicht 3D-Dateiformate
+<!-- Keine eigene Seite: wird in den Seiten der Kurse eingebettet -->
+### Übersicht 3D-Dateiformate
 
 **Proprietäre Formate** **(Softwaregebunden)**
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -16,6 +16,8 @@
   - [Thoughts on AI+Art](ai/thoughts-ai-art.md)
 - **🖥️ CAD and 3D Modeling**
   - [Fusion360](CAD/Fusion360.md)
+  - [Fusion360 Beginner Course](CAD/fusion360course/CAD1-beginner.md)
+  - [Fusion360 Advanced Course](CAD/fusion360course/CAD2-advanced.md)
   - [Blender](tools/blender.md)
 - **🔧 Related Tools**
   - [Python](tools/python.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -14,8 +14,10 @@
   - [Data & Datasets](ai/data-datasets.md)
   - [AI Artists](ai/ai-artists.md)
   - [Thoughts on AI+Art](ai/thoughts-ai-art.md)
-- **🔧 Related Tools**
+- **🖥️ CAD and 3D Modeling**
+  - [Fusion360](CAD/Fusion360)
   - [Blender](tools/blender.md)
+- **🔧 Related Tools**
   - [Python](tools/python.md)
 - **🤝 Contribute!**
   - [Guide](readme.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,7 +15,7 @@
   - [AI Artists](ai/ai-artists.md)
   - [Thoughts on AI+Art](ai/thoughts-ai-art.md)
 - **🖥️ CAD and 3D Modeling**
-  - [Fusion360](CAD/Fusion360)
+  - [Fusion360](CAD/Fusion360.md)
   - [Blender](tools/blender.md)
 - **🔧 Related Tools**
   - [Python](tools/python.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 Hi there! Thanks for coming by - feel free to have a look around 👀
 
-Obviously a lot of content ist still missing. We are always looking for help! If you have expertise you would like to share, check the [readme](docs/readme.md)!
+Obviously a lot of content ist still missing. We are always looking for help! If you have expertise you would like to share, check the [readme](readme.md)!
 
 ## This is us
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,5 +53,7 @@
   </script>
   <script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/external-script.min.js"></script>
+
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" media="screen and (prefers-color-scheme: dark)" href="https://cdn.jsdelivr.net/npm/prism-theme-night-owl@1.4.0/build/style.css">
   <link rel="stylesheet" href="assets/settings.css">
   <link rel="stylesheet" href="assets/overrides.css">
+  <link rel="stylesheet" href="https://unpkg.com/docsify-toc@1.0.0/dist/toc.css">
 </head>
 <body>
   <div id="app"></div>
@@ -44,6 +45,12 @@
           noData     : 'No results!',
           placeholder: 'Search...'
       },
+      toc: {
+          scope: '.markdown-section',
+          // headings: 'h1, h2, h3, h4, h5, h6',
+          headings: 'h1, h2', 
+          title: 'Contents',
+        },
       plugins: [
         EditOnGithubPlugin.create(
           'https://github.com/burglabs/xlab-docs/blob/main/'
@@ -51,6 +58,7 @@
       ]
     }
   </script>
+  <script src="https://unpkg.com/docsify-toc@1.0.0/dist/toc.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.js"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/external-script.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,6 @@
   <link rel="stylesheet" media="screen and (prefers-color-scheme: dark)" href="https://cdn.jsdelivr.net/npm/prism-theme-night-owl@1.4.0/build/style.css">
   <link rel="stylesheet" href="assets/settings.css">
   <link rel="stylesheet" href="assets/overrides.css">
-  <link rel="stylesheet" href="https://unpkg.com/docsify-toc@1.0.0/dist/toc.css">
 </head>
 <body>
   <div id="app"></div>
@@ -45,12 +44,6 @@
           noData     : 'No results!',
           placeholder: 'Search...'
       },
-      toc: {
-          scope: '.markdown-section',
-          // headings: 'h1, h2, h3, h4, h5, h6',
-          headings: 'h1, h2', 
-          title: 'Contents',
-        },
       plugins: [
         EditOnGithubPlugin.create(
           'https://github.com/burglabs/xlab-docs/blob/main/'
@@ -58,7 +51,6 @@
       ]
     }
   </script>
-  <script src="https://unpkg.com/docsify-toc@1.0.0/dist/toc.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.js"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/external-script.min.js"></script>


### PR DESCRIPTION
### Additions: 

1. Added 3 pages for Fusion 360:

     - General page
     - Fusion course advanced
     - Fusion course beginner
 
2. Added docsify plugin: [external-script](https://docsify.js.org/#/plugins?id=external-script)
      - necessary to show Pinterest iframe on the course page. 

3. Added `CAD AND 3D MODELING` section to the sidebar. 

Let me know if the pages should go somewhere else or if you had other plans for the structure. 
I would be open to splitting the Sessions of the course into subpages instead of one long page.